### PR TITLE
fix: correct copy path in setup-architect installation

### DIFF
--- a/.claude/skills/setup-architect/references/installation-procedures.md
+++ b/.claude/skills/setup-architect/references/installation-procedures.md
@@ -53,8 +53,8 @@ fi
 Copy the framework from the cloned location to `.architecture/`:
 
 ```bash
-# Copy all framework files
-cp -r .architecture/.architecture/* .architecture/
+# Copy framework files (they're in the .architecture subfolder of the cloned repo)
+cp -r .architecture/.architecture/.architecture/* .architecture/
 
 # Verify copy succeeded
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Fixes the copy command in `setup-architect` to reference the correct nested path

## Problem
The framework files are in the `.architecture` subfolder of the cloned repo, not at the repo root. The copy command was copying repo documentation (README.md, USAGE*.md, tools/, mcp/, etc.) instead of just the framework template files.

## Fix
Changed line 57 in `.claude/skills/setup-architect/references/installation-procedures.md`:

```diff
- cp -r .architecture/.architecture/* .architecture/
+ cp -r .architecture/.architecture/.architecture/* .architecture/
```

## Test plan
- [x] Verified fix installs only framework files (members.yml, principles.md, config.yml, templates/, etc.)
- [x] Confirmed repo documentation files are no longer copied to user projects

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)