### PR TITLE
Structural examination: version unification, two-tier MCP/Skills (ADR-015), setup fidelity (ADR-016)

### DIFF
--- a/.architecture/config.yml
+++ b/.architecture/config.yml
@@ -219,7 +219,7 @@ output:
 # Version tracking
 version:
   # Current framework version
-  framework_version: "1.2.0"
+  framework_version: "1.5.4"
 
   # Project architecture version (update with each major architecture change)
   architecture_version: "1.0.0"

--- a/.architecture/config.yml
+++ b/.architecture/config.yml
@@ -219,7 +219,7 @@ output:
 # Version tracking
 version:
   # Current framework version
-  framework_version: "1.5.4"
+  framework_version: "1.6.0"
 
   # Project architecture version (update with each major architecture change)
   architecture_version: "1.0.0"

--- a/.architecture/decisions/adrs/ADR-011-claude-marketplace-plugin-implementation.md
+++ b/.architecture/decisions/adrs/ADR-011-claude-marketplace-plugin-implementation.md
@@ -145,6 +145,15 @@ See [Research Document](../../research/claude-marketplace-requirements.md) for c
 
 ### Architectural Decision (Regardless of Path)
 
+> **Amended by [ADR-015](./ADR-015-mcp-skills-parity-reconciliation.md) (2026-06-16):** Two claims in
+> this section did not hold and are corrected there (this passage is preserved as the historical
+> record, per the append-only ADR-amendment convention). (1) "**95%+ code sharing**" (line below)
+> describes the *marketplace-wrapper → MCP-npm* relationship only; the MCP server and the Skills share
+> **zero** code — they are independent reimplementations. (2) "**All channels provide identical core
+> features**" is false for LLM-orchestrated reviews: those are plugin/Skills-only by capability (an MCP
+> server cannot dispatch host subagents). ADR-015 adopts a two-tier capability model and **removed** the
+> three MCP pseudo-review tools rather than continue implying parity.
+
 **If marketplace plugin is built, the architectural approach is:**
 
 **Thin Wrapper Architecture** with 95%+ code sharing:

--- a/.architecture/decisions/adrs/ADR-015-mcp-skills-parity-reconciliation.md
+++ b/.architecture/decisions/adrs/ADR-015-mcp-skills-parity-reconciliation.md
@@ -1,0 +1,360 @@
+# ADR-015: Reconciling MCP and Skills — Two-Tier Capability Model
+
+## Status
+
+Accepted
+
+> **History.** v1 (draft): rename the three MCP review tools to `scaffold_*` with deprecation aliases.
+> v2 (after the 8-architect review — see [adr-015-architecture-review.md](../../reviews/adr-015-architecture-review.md)
+> — and a live `setup_architecture` dogfood): corrected the false "Tier-1 is at parity" claim (P1),
+> reframed the overstated "MCP has no agent loop" rationale via the MCP `sampling` nuance (P2), added
+> `.claude/settings.json` to the blast radius (P4), dropped the deprecation aliases. **v3 (accepted,
+> 2026-06-16): the maintainer ratified Alternative 2 — DELETE the three Tier-2 MCP tools outright**
+> rather than rename them. The two-tier model and the P1/P2/P4 corrections are retained; the
+> `scaffold_*` rename is now a rejected alternative. The Tier-1 setup-parity fix is split into
+> [ADR-016](./ADR-016-setup-fidelity-canonical-sources.md).
+
+## Context
+
+ADR-011 founded the plugin's "thin wrapper" architecture on uniform feature parity: *"All channels
+provide identical core features (setup, ADR creation, reviews, status, pragmatic mode)"* and *"95%+ code
+sharing."* ADR-012 then bundled Skills, subagents, hooks, and the MCP server into one plugin.
+
+A structural examination
+([structural-first-principles-examination.md](../../reviews/structural-first-principles-examination.md))
+and the 8-architect review of this ADR found the parity claim contradicted by the channels' own
+behavior, and the "95% code sharing" figure misapplied:
+
+- The **Skills** `architecture-review` / `specialist-review` orchestrate real subagent reviews —
+  dispatching one subagent per team member via the Agent tool and aggregating (ADR-013).
+- The **MCP tools** of effectively the same name (`start_architecture_review`, `specialist_review`,
+  and `pragmatic_enforcer`) emit an **empty template/framework for manual completion** — two of them
+  write a blank template file into `.architecture/reviews/`; `pragmatic_enforcer` returns text only.
+- The MCP server (`mcp/index.js`, ~1,822 lines) and the Skills (`skills/*/SKILL.md`) **share zero
+  code** — two independent reimplementations. ADR-011's "95%+ code sharing" describes the
+  *marketplace-wrapper → MCP-npm* relationship only; it was never evidence of MCP↔Skills parity.
+
+A user who invokes the review operation gets a genuine multi-perspective review through the Skill and a
+hollow scaffold through the MCP tool of the same name, inside the same plugin. "Same name, different
+behavior" is the single coherence gap most likely to mislead.
+
+**Why the orchestrated tier cannot reach parity via MCP (corrected per review P2):** the MCP spec's
+`sampling` capability *does* let a server drive nested LLM completions through the host, so it is **not**
+true that "MCP can do no agentic work." The accurate — and stronger — statement is threefold:
+1. An MCP server **cannot dispatch the host's Agent/Task subagents**; orchestration as ADR-013 defines
+   it (forked-context subagents, parallel fan-out per member, persona isolation) is a host capability.
+2. Claude Code does **not currently expose `sampling`** (it exposes `elicitation`).
+3. Even if `sampling` were available, it is **single-shot and human-gated per call** — not the parallel
+   subagent fan-out a review requires.
+
+So orchestrated-review parity is **unavailable in this host and insufficient by mechanism**, not merely
+unbuilt. The MCP review tools return templates *because that is the most they can do* — which makes them
+low-value relative to the Skills a plugin user already has.
+
+**The deterministic tier is NOT actually at parity either (corrected per review P1).** The dogfood of
+`setup_architecture` produced a 6-member team omitting `pragmatic_enforcer`/`domain_expert`, using
+divergent ids, and never reading canonical `.architecture/members.yml`. Parity for the deterministic
+tier is therefore a **target, not a current fact**; the fix is [ADR-016](./ADR-016-setup-fidelity-canonical-sources.md).
+
+The framework's operations fall into two tiers, distinguished by **outcome**:
+
+| MCP tool | Outcome | Tier | Deterministic? | Reads canonical artifacts? | Disposition |
+|---|---|---|---|---|---|
+| `setup_architecture` | scaffolds `.architecture/` | 1 | Yes | **No (ADR-016)** | Keep; fix parity |
+| `create_adr` | writes a numbered ADR | 1 | Yes | n/a | Keep |
+| `list_architecture_members` | reads roster | 1 | Yes | Yes | Keep |
+| `get_architecture_status` | counts files | 1 | Yes | Yes | Keep |
+| `configure_pragmatic_mode` | edits config | 1 | Yes | Yes | Keep |
+| `get_implementation_guidance` | reads config.yml | 1 | Yes | Yes | Keep |
+| `start_architecture_review` | blank review template | 2 | No | — | **Remove** |
+| `specialist_review` | blank review template | 2 | No | — | **Remove** |
+| `pragmatic_enforcer` | blank analysis framework | 2 | No | — | **Remove** |
+
+**Tier-assignment rule (two axes):** an operation is **Tier 1** only if it is *both* deterministic *and*
+reads the same canonical artifacts as the other channels. An operation whose value is an LLM-produced
+analysis is **Tier 2** and belongs to the host-agent channels (plugin/Skills) only.
+
+## Decision Drivers
+
+* **Honesty of the contract**: a tool name is a promise read by the host model at selection time; a tool
+  that promises a review and delivers a blank template breaks it. The simplest way to stop making a
+  false promise is to stop shipping the tool.
+* **Simplicity**: the three tools are ~⅓ of `mcp/index.js` and produce only blank templates the host can
+  generate inline; removing them is a large, clean simplification with no internal callers.
+* **Accurate rationale**: the tier boundary rests on true platform constraints (no host subagent
+  dispatch; sampling unavailable and insufficient).
+* **Preserve MCP's real value**: the deterministic Tier-1 tools (and the static templates in
+  `templates/`) remain; MCP keeps doing what it can do honestly.
+* **Vocabulary integrity**: "channel" means *distribution* (ADR-011); the capability split needs its own
+  noun ("tier").
+
+## Decision
+
+Adopt an explicit **two-tier capability model** and **delete the three Tier-2 MCP tools**.
+
+**Tiers vs channels.** Tiers classify *operations* by capability/outcome; channels classify
+*distributions* by install method. They are orthogonal — every channel offers Tier 1; only host-agent
+channels (plugin/Skills) offer Tier 2.
+
+**Tier 1 — Deterministic operations (kept in MCP; parity is the target):** `setup_architecture`,
+`create_adr`, `list_architecture_members`, `get_architecture_status`, `configure_pragmatic_mode`,
+`get_implementation_guidance`. `setup_architecture` parity is fixed by ADR-016.
+
+**Tier 2 — LLM-produced analysis (plugin/Skills only):** architecture review, specialist review,
+pragmatic enforcement. Delivered by the Skills/subagents (ADR-013). Cost note for users: Tier-2
+orchestration fans out one subagent per active member and is the framework's most token- and
+latency-intensive operation (full review > specialist review > pragmatic pass); there is no cheaper MCP
+stand-in by design.
+
+**Remove the three Tier-2 MCP tools:** delete `start_architecture_review`, `specialist_review`, and
+`pragmatic_enforcer` from `mcp/index.js` (their schemas, switch cases, and handler bodies — ~600 lines,
+no internal callers). MCP then "does fewer things, all honestly." Rationale for deletion over renaming:
+the tools only ever emit blank templates a host agent can produce inline; the framework already ships
+those structures as static files (`.architecture/templates/review.md`, `adr.md`) that any MCP client can
+read; and no external caller is evidenced. Renaming would preserve a near-zero-value surface and a
+capability cliff; deletion erases both.
+
+**Migrate permissions:** remove the now-dead allow-list entries
+`mcp__ai-software-architect__start_architecture_review` and
+`mcp__ai-software-architect__specialist_review` from `.claude/settings.json`
+(`pragmatic_enforcer` is not allow-listed).
+
+**Update the parity claims (append-only):** annotate ADR-011 — both the "identical core features across
+all channels" sentence and the "thin wrapper / 95%+ code sharing" framing — with "Amended by ADR-015,"
+leaving its Status `Accepted`. Replace the docs' uniform-parity matrices with the two-tier table.
+
+**Non-goal:** this ADR does **not** consolidate the duplicated MCP and Skills implementations of Tier-1
+operations; that duplication persists and is deferred to a future ADR (ADR-016 fixes the most acute
+instance — the setup roster).
+
+**ADR-amendment convention (codified here):** Accepted ADRs are amended only by an append-only
+`> Amended by ADR-NNN (date)` annotation at the relevant passage; their bodies are never rewritten and
+their Status remains `Accepted`.
+
+**Architectural Components Affected:**
+* `mcp/index.js` — remove three tool schemas, three switch cases, three handler methods (~600 lines)
+* `.claude/settings.json` — remove two dead allow-list entries
+* `mcp/README.md`, `TROUBLESHOOTING.md`, `USAGE-WITH-CLAUDE.md` — remove references to the deleted tools
+* `ADR-011` — append-only amendment of the parity and code-sharing claims
+* Channel/feature matrices in `README.md`, `AGENTS.md`, `USAGE-WITH-CLAUDE-PLUGIN.md`, `.coding-assistants/*`
+* No change to Skills, subagents, hooks, or any Tier-1 tool
+
+**Interface Changes:**
+* Three MCP tools removed (breaking) — CHANGELOG "BREAKING" + minor version bump (held consistent by the
+  `version-check` guard from the version-unification work)
+* No schema/parameter changes to surviving tools
+
+## Consequences
+
+### Positive
+
+* The "same name, different behavior" trap is eliminated outright — there is no second tool to misread.
+* `mcp/index.js` shrinks ~⅓; the surviving surface is exactly the deterministic operations MCP can do
+  honestly.
+* The framework's documented contract matches actual behavior; the rationale survives a reader checking
+  the MCP spec.
+* Removes the maintenance and conceptual load of explaining a capability cliff forever.
+
+### Negative
+
+* Breaking change for any (unevidenced) MCP-only integration that scripted the three tools — mitigated
+  by CHANGELOG "BREAKING" + version bump.
+* MCP-only (non-Claude) clients lose a blank-template generator. Mitigation: the same structures exist as
+  static files in `.architecture/templates/` and can be read directly; no orchestrated review existed
+  there to lose.
+* Amending an Accepted ADR sets a precedent — bounded by the codified append-only convention.
+
+### Neutral
+
+* Surviving Tier-1 tools are unchanged (setup parity handled by ADR-016).
+* `members.yml`, the subagent generator, and the `pragmatic_enforcer` *subagent/member* (distinct from
+  the deleted MCP tool) are unaffected.
+
+## Implementation Strategy
+
+> Senior thinking on HOW and WHEN.
+
+### Blast Radius
+
+**Impact Scope**: Low–Medium. Removes ~600 lines from one file, two permission entries, and some doc
+references; touches the published MCP server's tool surface (breaking, announced).
+
+**Affected Components**: `mcp/index.js` (deletions), `.claude/settings.json`, MCP/usage docs, ADR-011
+(annotation), channel matrices.
+
+**Affected Teams**: Solo maintainer; downstream MCP-only integrators learn via CHANGELOG "BREAKING."
+
+**User Impact**: Plugin/Skills users unaffected. MCP users lose three blank-template tools; templates
+remain on disk.
+
+**Risk Mitigation**: deletions land in one commit with the settings.json migration; verified by a real
+`claude --plugin-dir ./` load (do not assume ADR-012 Phase-5 is live) asserting the surviving tool set;
+the `version-check` guard keeps the version bump consistent across channels.
+
+### Reversibility
+
+**Reversibility Level**: High. The change is deletions + text; a single `git revert` restores the tools.
+No data/schema migration.
+
+**Migration Paths**: Forward — delete tools + migrate allow-list (one commit) → docs + ADR-011
+annotation. Rollback — revert the commit. Evolution — if a real MCP-only need for structured templates
+emerges, expose the static `templates/` via a Tier-1 read tool rather than reviving pseudo-review tools.
+
+**Commitments Made**: MCP carries only Tier-1 operations; Tier-2 lives in the plugin/Skills.
+
+### Sequencing & Timing
+
+**Prerequisites**:
+- [x] ADR-013 accepted (defines Tier 2); ADR-011/012 plugin shipped
+- [ ] **Confirm against the current MCP SDK** that a server cannot dispatch host Agent/Task subagents
+  and that Claude Code does not expose `sampling` (validates the rationale) — gates the change
+- [ ] Confirm the ADR-012 Phase-5 smoke test runs the real CLI; if not, add a direct surviving-tool-set
+  load assertion
+
+**System Readiness**: Adequate. **Team Readiness**: High. **Data Migration**: None.
+
+**Sequencing Concerns**: tool deletion + allow-list migration must be atomic; doc/matrix updates follow.
+ADR-016 (setup parity) is independent.
+
+**Readiness Assessment**: Ready once the prerequisite confirmations pass.
+
+### Social Cost
+
+**Learning Curve**: Low — fewer tools, one concept ("tier ≠ channel").
+
+**Cognitive Load**: Reduced — nothing to explain about a hollow tool that no longer exists.
+
+**Clarity Assessment**: Helps more than confuses — MCP doing fewer things honestly is clearer than three
+tools that under-deliver.
+
+**Documentation Needs**:
+- [ ] CHANGELOG "BREAKING" entry for the removals
+- [ ] ADR-011 append-only amendment (parity + code-sharing)
+- [ ] Two-tier capability matrix in README/AGENTS/plugin docs
+- [ ] CI grep guard: the three tool names appear only in CHANGELOG/ADRs after removal
+
+### Confidence Assessment
+
+**Model Correctness Confidence**: High — anchored to verified platform facts and a reproduced behavior
+(the tools emit only blank templates).
+
+**Assumptions**:
+1. MCP servers cannot dispatch host Agent/Task subagents; Claude Code exposes `elicitation`, not
+   `sampling`. — **Validation**: verified against the MCP spec in review; re-confirm at implementation.
+2. No external MCP caller depends on the three tools. — **Validation**: unevidenced; accepted as the
+   basis for deletion. If one surfaces, expose `templates/` via a Tier-1 read tool instead of reviving
+   these.
+
+**Uncertainty Areas**: whether to later expose static templates via a small Tier-1 tool (deferred until
+a real need appears).
+
+**Validation Approach**: real-CLI load of the surviving tool set; CI grep guard; manual review of the
+rewritten matrices.
+
+**Edge Cases**: a user on an old MCP client after the bump — covered by CHANGELOG "BREAKING" + version
+pin.
+
+## Implementation
+
+**Phase 1: Remove the tools + migrate permissions (atomic)**
+* Delete the three tool schemas, switch cases, and handler methods from `mcp/index.js`.
+* Remove the two dead entries from `.claude/settings.json`.
+* CHANGELOG "BREAKING" entry; minor version bump (consistent via `version-check`).
+* Verify with `claude --plugin-dir ./` that the surviving tool set loads.
+
+**Phase 2: Reconcile the claims (docs)**
+* Append-only amend ADR-011 (parity + code-sharing) with "Amended by ADR-015."
+* Remove deleted-tool references from `mcp/README.md`, `TROUBLESHOOTING.md`, `USAGE-WITH-CLAUDE.md`.
+* Replace channel/feature matrices with the two-tier capability table.
+* Add the CI grep guard for the three tool names.
+
+## Alternatives Considered
+
+### Alternative A: Rename to `scaffold_*` with honest descriptions *(was the v2 decision — rejected)*
+
+Rename the three tools, reword descriptions, point to the Skill; no aliases.
+
+**Pros:** preserves a structured-template generator for non-Claude clients under an honest name.
+**Cons:** keeps a near-zero-value surface and a capability cliff to explain forever; ~600 lines of
+blank-template code remain. The maintainer judged the scaffold value ≈ zero (host can produce templates
+inline; static templates already on disk), so renaming preserves cost without benefit.
+
+### Alternative B: Make the MCP tools actually orchestrate reviews
+
+**Cons:** unavailable and insufficient — no host-subagent dispatch; Claude Code doesn't expose
+`sampling`; sampling is single-shot/human-gated, not ADR-013 fan-out. Would require embedding an agent
+runtime in the server.
+
+### Alternative C: Description-only fix (keep names and behavior)
+
+**Cons:** the tool *name* still reads as "do a review" and biases host selection; weakest option; leaves
+the dead-weight code.
+
+### Alternative D: Do nothing / prose caveat
+
+**Cons:** leaves the false parity claim and the same-name trap. Rejected.
+
+### Alternative E: Retire the MCP server entirely
+
+Out of scope; overbroad — MCP delivers real Tier-1 value (once ADR-016 lands). Deserves its own ADR.
+
+## Pragmatic Enforcer Analysis
+
+**Reviewer**: Pragmatic Enforcer (reconciled with the independent 8-architect review)
+**Mode**: Balanced
+
+**Overall Decision Complexity Assessment**:
+The accepted decision is *subtractive* — it removes ~⅓ of the MCP file and a whole confusion class, adds
+no runtime path, and introduces no abstraction. The independent review explicitly recommended deletion
+over the earlier rename-with-aliases as the simplest, most honest end-state; the maintainer ratified it.
+
+**Decision Challenge**:
+
+**Proposed Decision**: "Adopt a two-tier capability model and delete the three Tier-2 MCP tools;
+correct the parity/code-sharing claims; surviving Tier-1 setup parity handled by ADR-016."
+
+**Necessity Assessment**: 7/10 — an Accepted ADR makes claims the code contradicts and users hit a
+same-name/cost cliff today; deletion resolves it at the root.
+
+**Complexity Assessment**: 2/10 — deletions + doc edits + one allow-list change; net negative LOC.
+
+**Alternative Analysis**: Rename (A), description-only (C), and do-nothing (D) all preserve the
+dead-weight surface; orchestrate (B) is infeasible; retire-MCP (E) is overbroad. Deletion is the
+minimal honest change.
+
+**Recommendation**: ✅ Approve decision.
+
+**Pragmatic Score**:
+- **Necessity**: 7/10
+- **Complexity**: 2/10
+- **Ratio**: 0.29 *(Target: <1.5 for balanced mode)*
+
+**Overall Assessment**: Corrective and simplifying — removes surface rather than adding it.
+
+## Validation
+
+**Acceptance Criteria:**
+- [ ] `start_architecture_review`, `specialist_review`, `pragmatic_enforcer` are removed from
+  `mcp/index.js` (schemas, switch cases, handlers); a real `claude --plugin-dir ./` load shows only the
+  six Tier-1 tools.
+- [ ] `.claude/settings.json` no longer lists the two removed tools; no dead allow-list entries remain.
+- [ ] ADR-011's parity **and** code-sharing claims carry an append-only "Amended by ADR-015" annotation;
+  Status stays Accepted.
+- [ ] README/AGENTS/plugin docs show the two-tier capability matrix; `get_implementation_guidance`
+  appears in the Tier-1 list; no how-to doc references the removed tools.
+- [ ] CHANGELOG "BREAKING" entry present; version bumped consistently (`version-check` passes).
+- [ ] CI grep guard: the three tool names appear only in CHANGELOG/ADRs.
+
+**Testing Approach:**
+* Real-CLI load of the surviving tool set.
+* CI grep guard for residual references.
+* Manual review of the rewritten matrices against `mcp/index.js`.
+
+## References
+
+* [Architecture Review: ADR-015](../../reviews/adr-015-architecture-review.md) — the 8-architect review behind this decision
+* [ADR-016: Setup Must Derive Team and Stack from Canonical Sources](./ADR-016-setup-fidelity-canonical-sources.md) — the Tier-1 setup-parity fix
+* [ADR-011: Claude Marketplace Plugin Implementation](./ADR-011-claude-marketplace-plugin-implementation.md) — parity + code-sharing claims amended here
+* [ADR-012: Claude Plugin Distribution and Configuration Hardening](./ADR-012-claude-plugin-distribution-hardening.md) — bundled the surfaces; Phase-5 smoke test
+* [ADR-013: Skill Orchestrator Pattern with Subagent Delegation](./ADR-013-skill-orchestrator-subagent-delegation.md) — defines Tier-2 orchestration
+* [Structural First-Principles Examination](../../reviews/structural-first-principles-examination.md) — surfaced the parity gap

--- a/.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md
+++ b/.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md
@@ -4,102 +4,149 @@
 
 Proposed
 
-> Created via the framework's own ADR process. Companion to
-> [ADR-015](./ADR-015-mcp-skills-parity-reconciliation.md) (which tracks Tier-1 setup parity as
-> follow-up) and to the [ADR-015 architecture review](../../reviews/adr-015-architecture-review.md),
-> whose dogfood run surfaced these defects.
+> **Revision note (2026-06-16):** Revised after a full 8-architect review (see
+> [adr-016-architecture-review.md](../../reviews/adr-016-architecture-review.md)), which verified four
+> factual errors in the first draft against `mcp/index.js` and added a critical missing step. Changes:
+> corrected the false "setup reuses source-discovery / copies templates from the resolved source" claim
+> (F1 — it copies from `__dirname`); added subagent generation + `config.yml` seeding, without which a
+> seeded team is not dispatchable (F2); resolved the re-run guarantee, which was unbuilt and currently
+> blocked by an abort-on-existing guard (F3); corrected the drift to **4 missing members** and the
+> mislocated `principles.md` file (F4); folded in the Skill-doc reconciliation; added vocabulary,
+> security validation, and a discovery-failure policy; and trimmed scope (datastore surfacing and
+> dynamic analysis regeneration deferred). Companion to
+> [ADR-015](./ADR-015-mcp-skills-parity-reconciliation.md).
 
 ## Context
 
-A live dogfood of `setup_architecture` (MCP) against a fresh Rails + Express fixture (a `Gemfile` with
-`rails`/`sqlite3` plus a `package.json` with `express`) produced output that does not faithfully
-represent the framework's canonical model:
+A live dogfood of `setup_architecture` (MCP) against a Rails + Express fixture produced output that
+does not faithfully represent the framework's canonical model. Verified against `mcp/index.js`:
 
-1. **Divergent team.** Setup generated a 6-member roster (4 hardcoded base members + `javascript_expert`
-   + `express_specialist`). It **omitted `pragmatic_enforcer` and `domain_expert`**, and used divergent
-   ids (`security_architect` vs the canonical `security_specialist`). `customizeMembers`
-   (`mcp/index.js:471-548`) builds members from a hardcoded list and **never reads the canonical
-   `.architecture/members.yml`** that defines the 8 architects. A new project therefore starts with a
-   *structurally different and smaller* team than the framework documents — and silently loses the
-   pragmatic-enforcer that pragmatic mode depends on.
-2. **Stack misdetection.** Setup reported `Framework: Express` and built JS-oriented members while
-   **missing the Rails/Ruby stack entirely**, even though the package manager was correctly detected as
-   `bundler` — an internal inconsistency (Ruby package manager, JavaScript framework). The SQLite
-   dependency (in the `Gemfile`) was not surfaced anywhere. One manifest masked another.
-3. **Hardcoded initial analysis.** `initial-system-analysis.md` contains exactly four perspectives
-   (Systems, Security, Performance, Maintainability), independent of the actual roster, so it neither
-   reflects the generated team nor the canonical 8.
-4. **Broken generated link.** The generated analysis points to `.architecture/decisions/principles.md`;
-   the file is at `.architecture/principles.md`. (Ironic immediately after the 1.5.4 link-rot cleanup.)
+1. **Divergent, smaller team.** `customizeMembers` (line 394) hardcodes **4** base members and never
+   reads canonical `.architecture/members.yml`. Against the canonical **8**, it omits **four**
+   architects — `domain_expert`, `implementation_strategist`, `ai_engineer`, and `pragmatic_enforcer`
+   — and uses the wrong id `security_architect` (canonical: `security_specialist`). Even though setup
+   copies the framework dir to a temp clone, `customizeMembers` then **overwrites** the copied roster
+   with its hardcoded list (write at line 467).
+2. **The seeded team is not dispatchable.** Setup never runs the subagent generator, and `agents/*.md`
+   live at the **repo root** (not under `.architecture/`), so they are not carried into the target. A
+   fresh install has the team YAML but **zero `agents/*.md`** — reviews and pragmatic-mode reviews
+   cannot run end-to-end. Seeding the roster is necessary but not sufficient.
+3. **Stack misdetection.** `analyzeProject` reports a single `framework` (first-non-empty: Express wins
+   over Rails) and a single `packageManager` (last-write-wins: bundler), yielding the inconsistent
+   "Ruby package manager + JavaScript framework." The datastore (`sqlite3` in the Gemfile) is not
+   surfaced. The fix is to make these fields **multi-valued**, not to reorder checks.
+4. **Mislocated principles + broken link.** `customizePrinciples` **writes** principles to
+   `.architecture/decisions/principles.md` (line 525); the canonical location is
+   `.architecture/principles.md`. The wrong path is referenced at three sites (525/703/804). So the
+   file itself is mislocated, not merely linked wrong.
+5. **No source-discovery, and abort-on-existing.** Setup copies from `path.resolve(__dirname, '..')`
+   (line 229) — it does **not** use `tools/lib/setup-source-discovery.js` (that is wired only into
+   `tools/cli.js`). And setup **aborts** if `.architecture` already exists (line 206); there is no
+   merge/idempotency path today.
 
 The common root cause: **setup reimplements, in hardcoded form, knowledge that already exists
-canonically in the framework source** (the team in `members.yml`, the document structure in
-`templates/`, the perspectives in the subagents). ADR-015 generalized this as the second tier-assignment
-axis — *a Tier-1 operation must read the same canonical artifacts as the other channels* — and setup
-currently violates it.
+canonically** (the team in `members.yml`, the perspectives in the subagents, principles in
+`principles.md`). ADR-015's second tier-axis says a Tier-1 operation must read the same canonical
+artifacts as the other channels; setup currently violates it.
 
 ## Decision Drivers
 
-* **Fidelity**: a fresh install must reproduce the framework's actual team and principles, not a
-  lossy hardcoded subset.
-* **Single source of truth**: `members.yml` (and `templates/`, `principles.md`) already define the
-  canonical model; setup should seed from them, not duplicate them in code that drifts.
-* **Pragmatic-mode integrity**: omitting `pragmatic_enforcer` silently disables the reviewer pragmatic
-  mode relies on.
-* **Honest stack detection**: polyglot repos are common; detection must not let one manifest mask
-  another, and should surface the datastore.
-* **Consistency with ADR-015**: this is the tracked Tier-1 setup-parity fix that makes ADR-015's
-  "deterministic tier is at parity" claim actually true.
+* **Fidelity**: a fresh install must reproduce the framework's real, *usable* team — YAML **and**
+  dispatchable subagents — not a lossy hardcoded subset.
+* **Single source of truth**: `members.yml`, the subagents, and `principles.md` are canonical; setup
+  should derive from them, not duplicate them in code that drifts.
+* **Pragmatic-mode integrity**: omitting `pragmatic_enforcer` (and not generating its subagent or
+  seeding `pragmatic_mode` config) silently disables the reviewer pragmatic mode depends on.
+* **Honest stack detection**: polyglot repos are common; one manifest must not mask another.
+* **Truthful risk accounting**: wiring source-discovery into MCP setup is *new* work; the ADR must say
+  so (corrects the first draft).
 
 ## Decision
 
-**Setup derives its outputs from the framework's canonical sources, not from hardcoded logic.**
+**Setup derives its outputs from canonical sources, produces a *usable* install, and reports what it
+did.** Concretely:
 
-1. **Team from canonical `members.yml`.** `setup_architecture` seeds the new project's `members.yml`
-   by copying the framework's canonical roster (resolved via the existing source-discovery path) — all
-   8 architects with canonical ids, including `pragmatic_enforcer` and `domain_expert`. Stack-specific
-   advisors (e.g., a Rails or React specialist) may be **appended** to the canonical 8, never
-   substituted for them.
-2. **Full stack detection.** Detect across *all* manifests present (`Gemfile` → Ruby/Rails,
-   `package.json` → JS/framework, `requirements.txt`/`pyproject.toml` → Python, etc.) and surface the
-   datastore (e.g., `sqlite3` in the Gemfile) rather than reporting the first framework found. Report a
-   *set* of languages/frameworks, not a single masked value.
-3. **Roster-driven initial analysis.** Generate `initial-system-analysis.md` from the actual seeded
-   roster, so every member that exists contributes a perspective — no hardcoded 4.
-4. **Correct generated links.** Fix the `principles.md` path in the generated analysis and add the
-   generated analysis to the link-validation scope so this cannot regress.
+1. **Resolve the framework source via discovery (new).** Wire `discoverSource`
+   (`tools/lib/setup-source-discovery.js`) into `setup_architecture`, replacing the
+   `path.resolve(__dirname, '..')` shortcut. **Discovery-failure policy: fail loudly** — if the source
+   cannot be resolved, abort with guidance; **never** fall back to a partial hardcoded roster (that
+   would reintroduce the drift this ADR removes).
+2. **Seed the team from canonical `members.yml`, and validate it.** `customizeMembers` copies the
+   canonical roster (all 8 core members, canonical ids) and **replaces** its hardcoded write (line 467),
+   never appends over it. Before seeding, **validate**: assert the copied roster contains exactly the 8
+   canonical core ids (incl. `pragmatic_enforcer`, `domain_expert`); fail closed on a malformed/partial
+   roster. Stack-specific **advisors** may be appended (additive; never substitute a core member; ids
+   must not collide with any core id).
+3. **Make the team dispatchable (new — closes F2).** After seeding `members.yml`, setup **generates
+   `agents/*.md`** from it (invoke the existing `generateAll`) into the target, and **seeds `config.yml`
+   with the `pragmatic_mode` block** so `active_when: pragmatic_mode.enabled` can resolve. Acceptance
+   includes `agents/pragmatic-enforcer.md` existing post-setup.
+4. **Fix the principles location.** Write principles to canonical `.architecture/principles.md` (not
+   `decisions/principles.md`) and correct all three reference sites (525/703/804); add the generated
+   analysis to link validation.
+5. **Multi-valued stack detection (trimmed).** `analyzeProject` reports a **set** of languages and
+   frameworks so no manifest masks another; detection stays **root-only** (no recursion into
+   `node_modules`/`vendor`). **Sanitize** any manifest-derived value (framework/dep names) before it is
+   interpolated into ids or generated markdown; **bound** the number/size of manifests parsed, wrapping
+   each parse in try/catch. *(Deferred as out of scope: surfacing the datastore as a first-class field —
+   no consumer uses it yet; and dynamic roster-driven regeneration of the initial analysis — the
+   required outcome is only that generated links resolve and the analysis does not contradict the seeded
+   team.)*
+6. **Reconcile the Skill.** The `setup-architect` Skill already copies canonical `members.yml`, but its
+   docs encode a stale core (SKILL.md step 4 = 7 members; `customization-guide.md` = 6; checklist =
+   "seven"), omitting `implementation_strategist` and `ai_engineer`. Update those to reference the
+   canonical roster **by file**, not a hand-listed subset. Run the fidelity test against **both** the
+   MCP and Skill outputs.
+7. **Re-run behavior (resolve F3).** Setup **continues to abort** when `.architecture` exists; a
+   preserve-and-reseed-canonical-block merge (key: member `id`) is **future work**, tracked separately.
+   This ADR makes **fresh** installs correct; it does **not** claim non-destructive re-run (the first
+   draft's guarantee is withdrawn as unbuilt).
+8. **Observability.** Setup's output reports the seeded roster (count + ids), the generated subagents,
+   and the detected language/framework set — so an operator can trust an install without inspecting
+   files (this is how the bug survived).
+
+**Domain vocabulary (per review):** **member** = any roster entry; **core member** = one of the
+canonical 8 (the invariant floor); **advisor** = an appended, stack-derived member (additive, never
+substitutes a core member, id unique across the roster). "Advisor" is not called "specialist" (reserved
+for the canonical `*_specialist` core members).
 
 **Architectural Components Affected:**
-* `mcp/index.js` — `analyzeProject` (multi-manifest detection), `customizeMembers` (seed from canonical
-  `members.yml`), `conductInitialAnalysis` (roster-driven), the generated-link path
-* The `setup-architect` **skill** — same fidelity expectations, so MCP and Skill setup agree
-* `tools/` — a setup-fidelity test asserting the seeded roster equals the canonical 8 (+ any appended
-  advisors) and includes `pragmatic_enforcer`
+* `mcp/index.js` — wire `discoverSource`; `customizeMembers` (seed+validate+replace); new generator +
+  `config.yml` seeding step; `customizePrinciples` (correct location); `analyzeProject` (multi-valued,
+  sanitized, bounded); setup output (observability)
+* `skills/setup-architect/` — SKILL.md, `references/customization-guide.md`, success checklist:
+  reference the canonical roster by file
+* `tools/` — a setup-fidelity test (run against MCP and Skill outputs)
 
 **Interface Changes:**
-* No tool signature changes. Output of `setup_architecture` changes: full canonical team, richer stack
-  report. Existing installs are unaffected unless re-run.
+* No tool signatures change. `setup_architecture` output changes: full canonical team **+ generated
+  subagents + `pragmatic_mode` config**, richer stack report, principles at the canonical path.
 
 ## Consequences
 
 ### Positive
 
-* New projects start with the framework's real team and principles; pragmatic mode works out of the box.
-* Eliminates a silent MCP↔canonical drift and satisfies ADR-015's second tier axis (Tier-1 parity
-  becomes true and testable).
-* Polyglot repos are represented honestly; the datastore is visible to the security/performance lenses.
+* A fresh install is **usable**: canonical team, dispatchable subagents, pragmatic mode working — not
+  just a YAML file.
+* Eliminates the MCP↔canonical drift at the source and satisfies ADR-015's second tier axis (Tier-1
+  parity becomes true and testable).
+* Polyglot repos are represented honestly; principles live at the canonical path.
+* The risk is now stated truthfully (new discovery dependency), so the plan is trustworthy.
 
 ### Negative
 
-* Setup must resolve the framework source to read canonical `members.yml` — adds a dependency on
-  source-discovery succeeding (already required for templates; low marginal risk).
-* Slightly larger generated `members.yml` (8 + advisors vs 6); intended.
+* Larger than the first draft implied: a **new** source-discovery dependency for MCP setup (with a
+  fail-loud policy) and a new generator/ config-seeding step — not a "small extension."
+* Re-run still aborts on an existing `.architecture`; existing installs do not auto-gain the canonical
+  team (must re-init or await the future merge work).
+* The Skill and MCP remain two implementations (the shared-module refactor is deferred — ADR-015
+  non-goal); mitigated by running one fidelity test against both.
 
 ### Neutral
 
-* The subagent generator and Skills are unaffected (they already read canonical `members.yml`).
-* Re-running setup on an existing project should remain non-destructive to a customized `members.yml`
-  (preserve existing; this ADR does not change merge behavior).
+* `members.yml` becomes the authoritative team source for setup, not code.
+* Datastore surfacing and dynamic analysis regeneration are deferred until a consumer/justification
+  exists.
 
 ## Implementation Strategy
 
@@ -107,175 +154,192 @@ currently violates it.
 
 ### Blast Radius
 
-**Impact Scope**: Medium. Affects every future `setup_architecture` (and `setup-architect` skill) run;
-does not touch existing installs unless re-run.
+**Impact Scope**: Medium. Affects every future `setup_architecture` (and the `setup-architect` Skill
+docs); existing installs are untouched (re-run still aborts). Introduces a runtime dependency on
+source-discovery resolving at MCP/npx time — the key new failure mode (handled by the fail-loud policy).
 
-**Affected Components**: `analyzeProject`, `customizeMembers`, `conductInitialAnalysis` in
-`mcp/index.js`; the `setup-architect` skill; a new setup-fidelity test.
+**Affected Components**: `analyzeProject`, `customizeMembers`, `customizePrinciples`,
+`conductInitialAnalysis`, and a new generator/config step in `mcp/index.js`; the Skill docs; a new test.
 
-**Affected Teams**: Solo maintainer; downstream new adopters benefit.
+**User Impact**: New installs get a usable, full team. No change for existing users until they re-init.
 
-**User Impact**: New installs get the full team and accurate stack report. No change for existing users
-until they re-run setup.
-
-**Risk Mitigation**: seed-from-canonical reuses the proven source-discovery path; a fidelity test
-golden-checks the seeded roster against canonical `members.yml`; re-run preserves customized members.
+**Risk Mitigation**: fail-loud discovery policy; roster validation (fail closed); fidelity test across
+both surfaces; sanitize/bound untrusted manifest parsing.
 
 ### Reversibility
 
-**Reversibility Level**: High. Logic changes within setup helpers; revert restores prior behavior. No
-data migration (only affects newly generated files).
+**Reversibility Level**: High. Logic changes within setup helpers + Skill doc edits; revert restores
+prior behavior. No data migration (only newly generated files).
 
-**Migration Paths**: Forward — update detection + seeding + analysis, add test. Rollback — revert the
-commit. Evolution — appended stack advisors can grow without touching the canonical 8.
+**Migration Paths**: Forward — wire discovery → seed+validate+generate+config → fix principles location
+→ multi-valued detection → Skill docs → test. Rollback — revert. Evolution — appended advisors and the
+future re-run merge build on this without rework.
 
-**Options Preserved**: how advisors are chosen per stack remains tunable; canonical seed is the floor.
-
-**Commitments Made**: `members.yml` is the authoritative team source for setup, not code.
+**Commitments Made**: `members.yml` + the subagents + `principles.md` are the canonical sources setup
+must derive from; setup fails loudly rather than seeding a partial roster.
 
 ### Sequencing & Timing
 
 **Prerequisites**:
-- [x] Source-discovery path exists (`tools/lib/setup-source-discovery.js`) and resolves the framework root
-- [ ] Decide advisor-selection policy per detected stack (can ship with "none" initially — canonical 8 only)
+- [x] `tools/lib/setup-source-discovery.js` exists and resolves the framework root (used by the CLI)
+- [ ] Confirm `generateAll` can run against a freshly-seeded `members.yml` in the target context
+- [ ] Decide advisor-selection policy per stack (ship with **none** initially — canonical 8 only)
 
-**System Readiness**: Adequate — setup already copies templates from the resolved source; reading
-`members.yml` from the same source is a small extension.
+**System Readiness**: The discovery path exists but is **not yet wired into MCP setup** (corrects the
+first draft); Phase 0 wires it. No new deps; no data migration.
 
-**Team Readiness**: High; no new concepts.
+**Team Readiness**: High; no new concepts beyond the vocabulary block.
 
-**Sequencing Concerns**: Land detection + seeding together (a richer roster without richer detection is
-fine; the reverse is not). The link-path fix is independent and can land first.
+**Sequencing Concerns**: Phase 0 (wire discovery) gates seeding. Generation must follow seeding. The
+link/location fix is independent and can land first. Skill-doc reconciliation can land in parallel.
 
-**Readiness Assessment**: Ready to implement.
+**Readiness Assessment**: Ready once the `generateAll`-in-target check passes.
 
 ### Social Cost
 
-**Learning Curve**: Low.
+**Learning Curve**: Low. **Cognitive Load**: Reduced (one source of truth for the team).
 
-**Cognitive Load**: Reduced — one source of truth for the team instead of two (code + YAML).
-
-**Clarity Assessment**: Helps. A fresh install matching the docs is less confusing than a silently
-smaller team. Explanation: a CHANGELOG note that setup now seeds the full canonical team.
+**Clarity Assessment**: Helps — a fresh install that matches the docs and actually runs reviews is far
+less confusing than a silently lossy one. Explanation: a CHANGELOG note that setup seeds the full
+canonical team **and** generates its subagents.
 
 **Documentation Needs**:
 - [ ] CHANGELOG entry
-- [ ] Note in setup docs that the full canonical team is seeded and stack advisors are appended
+- [ ] Setup docs: full canonical team is seeded, subagents generated, advisors appended
+- [ ] Skill docs reference the canonical roster by file
 
 ### Confidence Assessment
 
-**Model Correctness Confidence**: High — the defects are reproduced (dogfood), and the fix removes a
-duplication rather than adding a model.
+**Model Correctness Confidence**: High — defects reproduced and verified in code; the fix removes
+duplication.
 
 **Assumptions**:
-1. Source discovery reliably resolves the framework root during setup. — **Validation**: already relied
-   on for templates; covered by `setup-source-discovery` tests.
-2. Appending advisors to the canonical 8 is preferable to substitution. — **Validation**: matches the
-   framework's stated 8-member model; revisit if a stack genuinely needs a core member replaced.
+1. `discoverSource` resolves the framework root at MCP/npx runtime. — **Validation**: covered by
+   `setup-source-discovery` tests for the CLI; **must be re-validated in the MCP runtime context** (new
+   usage). Fail-loud policy bounds the downside.
+2. `generateAll` runs correctly against a seeded `members.yml` in the target. — **Validation**: Phase
+   check before relying on it.
+3. Appending advisors (vs substitution) matches the 8-member model. — **Validation**: fidelity test
+   enforces core-block equality.
 
-**Uncertainty Areas**: advisor-selection heuristics per stack; whether the Skill and MCP should share a
-single detection module to prevent re-divergence (likely yes — see ADR-015's duplication non-goal).
+**Uncertainty Areas**: advisor-selection heuristics; whether MCP and the Skill should share one
+detection/seeding module (ADR-015 duplication non-goal — deferred; both bound to the fidelity test
+meanwhile); the future re-run merge semantics.
 
-**Validation Approach**: a setup-fidelity test that runs setup against polyglot fixtures and asserts
-(a) the seeded roster ⊇ the canonical 8 including `pragmatic_enforcer`, (b) all present manifests are
-detected, (c) the datastore is surfaced, (d) generated links resolve.
+**Validation Approach**: a setup-fidelity test over polyglot fixtures asserting (a) the seeded core
+block equals the canonical ids **exactly** (catches omission **and** id-drift like
+`security_architect`), plus zero-or-more advisors with unique ids; (b) all present manifests detected;
+(c) `agents/<kebab-id>.md` exists for every seeded member, incl. `pragmatic-enforcer`; (d) `config.yml`
+contains `pragmatic_mode`; (e) generated links resolve and principles are at the canonical path. Run
+against **both** MCP and Skill outputs.
 
-**Edge Cases**: monorepos with multiple manifests of the same ecosystem; a project that already has a
-customized `members.yml` (must be preserved on re-run).
+**Edge Cases**: monorepos with many manifests (bounded, root-only); malformed/hostile manifest (parse
+in try/catch, sanitize derived values); tampered/spoofed source (validate copied roster, fail closed);
+existing `.architecture` (abort — re-run merge is future work).
 
 ## Implementation
 
-**Phase 1: Stack detection + generated-link fix**
-* Make `analyzeProject` scan all manifests and report language/framework *sets* + datastore.
-* Fix the `principles.md` path in `conductInitialAnalysis`; add the generated analysis to link validation.
+**Phase 0: Wire source-discovery into MCP setup**
+* Replace `path.resolve(__dirname,'..')` with `discoverSource(...)`; fail loudly on resolution failure.
 
-**Phase 2: Canonical team seeding**
-* Change `customizeMembers` to copy the framework's canonical `members.yml` (via source discovery) as the
-  base, then append any stack advisors. Never drop the canonical 8.
+**Phase 1: Detection + principles location + link fix**
+* `analyzeProject` reports multi-valued languages/frameworks (root-only, sanitized, bounded).
+* `customizePrinciples` writes to `.architecture/principles.md`; fix the 3 reference sites; add the
+  generated analysis to link validation.
 
-**Phase 3: Roster-driven analysis + fidelity test**
-* Generate `initial-system-analysis.md` from the seeded roster.
-* Add the setup-fidelity test (polyglot fixtures; assert canonical-8 ⊆ roster, multi-manifest detection,
-  datastore surfaced, links resolve).
+**Phase 2: Canonical team seeding (+ validation, replace not append)**
+* `customizeMembers` copies + validates canonical `members.yml` (fail closed if not the canonical 8);
+  replaces the line-467 write; appends advisors (none initially) with id-uniqueness.
+
+**Phase 3: Make it dispatchable**
+* Generate `agents/*.md` from the seeded roster (`generateAll`); seed `config.yml` with `pragmatic_mode`.
+
+**Phase 4: Skill reconciliation + fidelity test + observability**
+* Update Skill docs to reference the canonical roster by file.
+* Add the setup-fidelity test (run against MCP and Skill outputs).
+* Setup reports seeded roster + generated subagents + detected stack.
 
 ## Alternatives Considered
 
-### Alternative 1: Keep hardcoded members; just add the missing ones
-
-Add `pragmatic_enforcer`/`domain_expert` to the hardcoded list and fix ids.
+### Alternative 1: Keep hardcoded members; just add the missing ones + fix ids
 
 **Pros:** smallest diff.
-**Cons:** leaves the duplication that caused the drift; the hardcoded list will diverge from
-`members.yml` again the next time the canonical team changes. Treats the symptom, not the cause.
+**Cons:** the hardcoded list has already drifted (wrong id, **4 of 8** missing); patching it re-drifts
+the next time the canonical team changes, and does nothing for F2 (no subagents) or the principles
+location. Treats symptoms.
 
 ### Alternative 2: Do nothing; document that MCP setup yields a reduced team
 
-**Pros:** zero work.
-**Cons:** ships a silently lossy install that contradicts the docs and breaks pragmatic mode; leaves
-ADR-015's Tier-1 parity claim false.
+**Cons:** ships a silently lossy, non-functional install; leaves ADR-015's Tier-1 parity claim false.
 
-### Alternative 3: Share one detection/seeding module between the Skill and MCP
-
-Extract setup logic into a shared module both surfaces import.
+### Alternative 3: Share one detection/seeding module between Skill and MCP
 
 **Pros:** prevents future MCP↔Skill divergence at the source (the real fix).
-**Cons:** larger refactor; overlaps ADR-015's deferred "consolidate duplication" non-goal. Worth doing,
-but bigger than this ADR — fold into the duplication-consolidation ADR rather than block this fix.
+**Cons:** larger refactor overlapping ADR-015's deferred "consolidate duplication" non-goal. Deferred —
+but both surfaces are bound to the same fidelity test meanwhile so divergence is caught.
 
 ## Pragmatic Enforcer Analysis
 
-**Reviewer**: Pragmatic Enforcer
+**Reviewer**: Pragmatic Enforcer (reconciled with the independent review panel)
 **Mode**: Balanced
 
 **Overall Decision Complexity Assessment**:
-This fixes concrete, reproduced defects by *removing* duplicated knowledge (hardcoded team) in favor of
-the canonical source. It adds detection breadth and one test — proportionate. The temptation to
-over-reach (Alternative 3's shared-module refactor) is explicitly deferred.
+The core (seed-from-canonical, replacing a drifted hardcoded list) *removes* duplication. The review
+correctly flagged that the first draft both **under-scoped** (missing F2 — generation/config, without
+which the install doesn't work) and **over-scoped** (datastore surfacing, dynamic analysis regen — no
+consumer). This revision adds the necessary completeness and defers the gold-plating.
 
 **Decision Challenge**:
 
-**Proposed Decision**: "Setup seeds the full canonical team from `members.yml`, detects all manifests,
-drives the initial analysis from the roster, and fixes generated links."
+**Proposed Decision**: "Setup resolves the source via discovery, seeds + validates the canonical team,
+generates its subagents, seeds pragmatic config, fixes the principles location, detects all manifests,
+and reconciles the Skill docs."
 
-**Necessity Assessment**: 8/10 — reproduced defects that ship a lossy install and break pragmatic mode;
-also unblocks ADR-015's parity claim. Present, not speculative.
+**Necessity Assessment**: 7/10 — reproduced defects that ship a non-functional, lossy install and break
+pragmatic mode; also unblocks ADR-015's parity claim.
 
-**Complexity Assessment**: 3/10 — bounded changes to three setup helpers + a fidelity test; reuses
-existing source discovery; no new deps.
+**Complexity Assessment**: 5/10 — honestly higher than the first draft's self-rated 3: a new discovery
+dependency, a generation/config step, detection changes, and Skill reconciliation. The independent
+panel scored the *original* at Necessity 7 / Complexity 5 / **Ratio 0.71**; trimming the scope (defer
+datastore + dynamic analysis) and removing the unbuilt re-run guarantee brings the *necessary* work's
+ratio back toward ~0.5.
 
-**Alternative Analysis**: "Do nothing" and "patch the hardcoded list" were considered; both leave the
-root duplication. The shared-module refactor is the deeper fix but is deferred to avoid scope creep.
+**Alternative Analysis**: Alt 1 (patch the list) re-drifts and ignores F2; Alt 2 ships broken; Alt 3 is
+the deeper fix, deferred with a test-based guard.
 
-**Simpler Alternative Proposal**: Phase 1 (detection + link fix) alone removes the most visible defects
-if Phase 2 must wait; but Phase 2 is the one that fixes the parity root cause and should not be skipped.
+**Recommendation**: ✅ Approve decision (scope-trimmed).
 
-**Recommendation**: ✅ Approve decision
+**Pragmatic Score (revised, scope-trimmed)**:
+- **Necessity**: 7/10
+- **Complexity**: 5/10
+- **Ratio**: 0.71 *(Target: <1.5 — clears the balanced gate; honest, not the first draft's 0.38)*
 
-**Pragmatic Score**:
-- **Necessity**: 8/10
-- **Complexity**: 3/10
-- **Ratio**: 0.38 *(Target: <1.5 for balanced mode)*
-
-**Overall Assessment**: Appropriate, root-cause fix for current defects; defers the larger refactor
-honestly.
+**Overall Assessment**: Appropriate root-cause fix once corrected for completeness and trimmed of
+speculative additions.
 
 ## Validation
 
 **Acceptance Criteria:**
-- [ ] Setup against a polyglot fixture seeds a `members.yml` containing all 8 canonical architects
-  (incl. `pragmatic_enforcer`, `domain_expert`) with canonical ids, plus any appended stack advisors.
-- [ ] All present manifests are detected (Ruby/Rails + JS/Express in the dogfood case) and the datastore
-  is surfaced.
-- [ ] `initial-system-analysis.md` reflects the seeded roster and contains no broken links.
-- [ ] A setup-fidelity test enforces the above and runs under `npm test`.
-- [ ] Re-running setup on a project with a customized `members.yml` preserves it.
+- [ ] MCP setup resolves the source via `discoverSource` and **fails loudly** (no partial seed) if it
+  cannot.
+- [ ] The seeded core block equals the canonical ids **exactly** (incl. `pragmatic_enforcer`,
+  `domain_expert`, `implementation_strategist`, `ai_engineer`; `security_specialist` not
+  `security_architect`), plus zero-or-more advisors with unique ids.
+- [ ] `agents/<kebab-id>.md` exists for every seeded member after setup; `config.yml` contains
+  `pragmatic_mode`.
+- [ ] Principles are written to `.architecture/principles.md`; generated links resolve.
+- [ ] All present manifests are detected (Ruby/Rails + JS/Express in the dogfood case); manifest-derived
+  values are sanitized; the scan is bounded/root-only.
+- [ ] Skill docs reference the canonical roster by file; the fidelity test runs against **both** MCP and
+  Skill outputs under `npm test`.
+- [ ] Setup output reports the seeded roster + generated subagents + detected stack.
 
 **Testing Approach:**
-* Setup-fidelity test over polyglot fixtures (assert roster ⊇ canonical 8, multi-manifest detection,
-  datastore surfaced, links resolve); golden compare the seeded roster to canonical `members.yml`.
+* Setup-fidelity test over polyglot fixtures (stub manifests), asserting the criteria above; run against
+  MCP and Skill outputs.
 
 ## References
 
+* [Architecture Review: ADR-016](../../reviews/adr-016-architecture-review.md) — the 8-architect review this revision incorporates
 * [ADR-015: Reconciling MCP and Skills](./ADR-015-mcp-skills-parity-reconciliation.md) — second tier axis; tracks this as the Tier-1 setup-parity fix
-* [Architecture Review: ADR-015](../../reviews/adr-015-architecture-review.md) — dogfood that surfaced these defects
 * [Structural First-Principles Examination](../../reviews/structural-first-principles-examination.md) — the MCP↔canonical drift theme

--- a/.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md
+++ b/.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md
@@ -2,8 +2,16 @@
 
 ## Status
 
-Proposed
+Accepted
 
+> **Status (2026-06-16):** Accepted and implemented (core: preserve canonical members.yml + fail-closed
+> validation, generate subagents, seed pragmatic config via the copied canonical config, fix the
+> principles location, multi-valued stack detection, Skill-doc reconciliation, and an end-to-end
+> fidelity test). The implementation found a simplification the draft missed: setup already copies the
+> canonical files in, so the fix is to **stop overwriting** them — the discovery-rewiring (Phase 0) is
+> not needed for the team fix and remains a deferred robustness follow-up, along with the re-run merge,
+> the shared MCP/Skill module, and datastore surfacing.
+>
 > **Revision note (2026-06-16):** Revised after a full 8-architect review (see
 > [adr-016-architecture-review.md](../../reviews/adr-016-architecture-review.md)), which verified four
 > factual errors in the first draft against `mcp/index.js` and added a critical missing step. Changes:

--- a/.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md
+++ b/.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md
@@ -57,6 +57,19 @@ canonically** (the team in `members.yml`, the perspectives in the subagents, pri
 `principles.md`). ADR-015's second tier-axis says a Tier-1 operation must read the same canonical
 artifacts as the other channels; setup currently violates it.
 
+**Related contributor work (issue #9 / PR #10, by sgbett).** Independently, sgbett identified a
+*complementary* setup defect: the install also copies the framework's **own** work product — its
+internal ADRs, reviews, comparisons, and `deferrals.md` — into target projects as cruft. This ADR does
+not fix that leak; PR #10 does, via a manifest that copies only what a new project needs. (Note #9's
+premise that the MCP path is already clean is outdated — `setupArchitecture` still moves the entire
+`.architecture/` into the target, so the leak affects both paths.) The two efforts converge cleanly: the
+manifest should **copy** the canonical `members.yml`/`principles.md` and **exclude** the framework's own
+decisions/reviews/comparisons/deferrals — pairing #10's exclusion with this ADR's
+copy-canonical-and-validate rule, with subagent generation running off the copied roster. A single
+manifest-driven installer shared by the MCP and skill paths is the natural end state (cf. ADR-015's
+deferred shared-module non-goal). Convergence is being coordinated on PR #10; pending that, manifest-based
+cruft exclusion is tracked as follow-up here rather than implemented in this ADR.
+
 ## Decision Drivers
 
 * **Fidelity**: a fresh install must reproduce the framework's real, *usable* team — YAML **and**
@@ -351,3 +364,5 @@ speculative additions.
 * [Architecture Review: ADR-016](../../reviews/adr-016-architecture-review.md) — the 8-architect review this revision incorporates
 * [ADR-015: Reconciling MCP and Skills](./ADR-015-mcp-skills-parity-reconciliation.md) — second tier axis; tracks this as the Tier-1 setup-parity fix
 * [Structural First-Principles Examination](../../reviews/structural-first-principles-examination.md) — the MCP↔canonical drift theme
+* [Issue #9: Skills-based setup copies framework's own files into target projects](https://github.com/codenamev/ai-software-architect/issues/9) — complementary cruft-leak defect (sgbett)
+* [PR #10: manifest-based selective installation for skills setup](https://github.com/codenamev/ai-software-architect/pull/10) — the manifest fix this ADR converges with (sgbett)

--- a/.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md
+++ b/.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md
@@ -1,0 +1,281 @@
+# ADR-016: Setup Must Derive Team and Stack from Canonical Sources
+
+## Status
+
+Proposed
+
+> Created via the framework's own ADR process. Companion to
+> [ADR-015](./ADR-015-mcp-skills-parity-reconciliation.md) (which tracks Tier-1 setup parity as
+> follow-up) and to the [ADR-015 architecture review](../../reviews/adr-015-architecture-review.md),
+> whose dogfood run surfaced these defects.
+
+## Context
+
+A live dogfood of `setup_architecture` (MCP) against a fresh Rails + Express fixture (a `Gemfile` with
+`rails`/`sqlite3` plus a `package.json` with `express`) produced output that does not faithfully
+represent the framework's canonical model:
+
+1. **Divergent team.** Setup generated a 6-member roster (4 hardcoded base members + `javascript_expert`
+   + `express_specialist`). It **omitted `pragmatic_enforcer` and `domain_expert`**, and used divergent
+   ids (`security_architect` vs the canonical `security_specialist`). `customizeMembers`
+   (`mcp/index.js:471-548`) builds members from a hardcoded list and **never reads the canonical
+   `.architecture/members.yml`** that defines the 8 architects. A new project therefore starts with a
+   *structurally different and smaller* team than the framework documents — and silently loses the
+   pragmatic-enforcer that pragmatic mode depends on.
+2. **Stack misdetection.** Setup reported `Framework: Express` and built JS-oriented members while
+   **missing the Rails/Ruby stack entirely**, even though the package manager was correctly detected as
+   `bundler` — an internal inconsistency (Ruby package manager, JavaScript framework). The SQLite
+   dependency (in the `Gemfile`) was not surfaced anywhere. One manifest masked another.
+3. **Hardcoded initial analysis.** `initial-system-analysis.md` contains exactly four perspectives
+   (Systems, Security, Performance, Maintainability), independent of the actual roster, so it neither
+   reflects the generated team nor the canonical 8.
+4. **Broken generated link.** The generated analysis points to `.architecture/decisions/principles.md`;
+   the file is at `.architecture/principles.md`. (Ironic immediately after the 1.5.4 link-rot cleanup.)
+
+The common root cause: **setup reimplements, in hardcoded form, knowledge that already exists
+canonically in the framework source** (the team in `members.yml`, the document structure in
+`templates/`, the perspectives in the subagents). ADR-015 generalized this as the second tier-assignment
+axis — *a Tier-1 operation must read the same canonical artifacts as the other channels* — and setup
+currently violates it.
+
+## Decision Drivers
+
+* **Fidelity**: a fresh install must reproduce the framework's actual team and principles, not a
+  lossy hardcoded subset.
+* **Single source of truth**: `members.yml` (and `templates/`, `principles.md`) already define the
+  canonical model; setup should seed from them, not duplicate them in code that drifts.
+* **Pragmatic-mode integrity**: omitting `pragmatic_enforcer` silently disables the reviewer pragmatic
+  mode relies on.
+* **Honest stack detection**: polyglot repos are common; detection must not let one manifest mask
+  another, and should surface the datastore.
+* **Consistency with ADR-015**: this is the tracked Tier-1 setup-parity fix that makes ADR-015's
+  "deterministic tier is at parity" claim actually true.
+
+## Decision
+
+**Setup derives its outputs from the framework's canonical sources, not from hardcoded logic.**
+
+1. **Team from canonical `members.yml`.** `setup_architecture` seeds the new project's `members.yml`
+   by copying the framework's canonical roster (resolved via the existing source-discovery path) — all
+   8 architects with canonical ids, including `pragmatic_enforcer` and `domain_expert`. Stack-specific
+   advisors (e.g., a Rails or React specialist) may be **appended** to the canonical 8, never
+   substituted for them.
+2. **Full stack detection.** Detect across *all* manifests present (`Gemfile` → Ruby/Rails,
+   `package.json` → JS/framework, `requirements.txt`/`pyproject.toml` → Python, etc.) and surface the
+   datastore (e.g., `sqlite3` in the Gemfile) rather than reporting the first framework found. Report a
+   *set* of languages/frameworks, not a single masked value.
+3. **Roster-driven initial analysis.** Generate `initial-system-analysis.md` from the actual seeded
+   roster, so every member that exists contributes a perspective — no hardcoded 4.
+4. **Correct generated links.** Fix the `principles.md` path in the generated analysis and add the
+   generated analysis to the link-validation scope so this cannot regress.
+
+**Architectural Components Affected:**
+* `mcp/index.js` — `analyzeProject` (multi-manifest detection), `customizeMembers` (seed from canonical
+  `members.yml`), `conductInitialAnalysis` (roster-driven), the generated-link path
+* The `setup-architect` **skill** — same fidelity expectations, so MCP and Skill setup agree
+* `tools/` — a setup-fidelity test asserting the seeded roster equals the canonical 8 (+ any appended
+  advisors) and includes `pragmatic_enforcer`
+
+**Interface Changes:**
+* No tool signature changes. Output of `setup_architecture` changes: full canonical team, richer stack
+  report. Existing installs are unaffected unless re-run.
+
+## Consequences
+
+### Positive
+
+* New projects start with the framework's real team and principles; pragmatic mode works out of the box.
+* Eliminates a silent MCP↔canonical drift and satisfies ADR-015's second tier axis (Tier-1 parity
+  becomes true and testable).
+* Polyglot repos are represented honestly; the datastore is visible to the security/performance lenses.
+
+### Negative
+
+* Setup must resolve the framework source to read canonical `members.yml` — adds a dependency on
+  source-discovery succeeding (already required for templates; low marginal risk).
+* Slightly larger generated `members.yml` (8 + advisors vs 6); intended.
+
+### Neutral
+
+* The subagent generator and Skills are unaffected (they already read canonical `members.yml`).
+* Re-running setup on an existing project should remain non-destructive to a customized `members.yml`
+  (preserve existing; this ADR does not change merge behavior).
+
+## Implementation Strategy
+
+> Senior thinking on HOW/WHEN.
+
+### Blast Radius
+
+**Impact Scope**: Medium. Affects every future `setup_architecture` (and `setup-architect` skill) run;
+does not touch existing installs unless re-run.
+
+**Affected Components**: `analyzeProject`, `customizeMembers`, `conductInitialAnalysis` in
+`mcp/index.js`; the `setup-architect` skill; a new setup-fidelity test.
+
+**Affected Teams**: Solo maintainer; downstream new adopters benefit.
+
+**User Impact**: New installs get the full team and accurate stack report. No change for existing users
+until they re-run setup.
+
+**Risk Mitigation**: seed-from-canonical reuses the proven source-discovery path; a fidelity test
+golden-checks the seeded roster against canonical `members.yml`; re-run preserves customized members.
+
+### Reversibility
+
+**Reversibility Level**: High. Logic changes within setup helpers; revert restores prior behavior. No
+data migration (only affects newly generated files).
+
+**Migration Paths**: Forward — update detection + seeding + analysis, add test. Rollback — revert the
+commit. Evolution — appended stack advisors can grow without touching the canonical 8.
+
+**Options Preserved**: how advisors are chosen per stack remains tunable; canonical seed is the floor.
+
+**Commitments Made**: `members.yml` is the authoritative team source for setup, not code.
+
+### Sequencing & Timing
+
+**Prerequisites**:
+- [x] Source-discovery path exists (`tools/lib/setup-source-discovery.js`) and resolves the framework root
+- [ ] Decide advisor-selection policy per detected stack (can ship with "none" initially — canonical 8 only)
+
+**System Readiness**: Adequate — setup already copies templates from the resolved source; reading
+`members.yml` from the same source is a small extension.
+
+**Team Readiness**: High; no new concepts.
+
+**Sequencing Concerns**: Land detection + seeding together (a richer roster without richer detection is
+fine; the reverse is not). The link-path fix is independent and can land first.
+
+**Readiness Assessment**: Ready to implement.
+
+### Social Cost
+
+**Learning Curve**: Low.
+
+**Cognitive Load**: Reduced — one source of truth for the team instead of two (code + YAML).
+
+**Clarity Assessment**: Helps. A fresh install matching the docs is less confusing than a silently
+smaller team. Explanation: a CHANGELOG note that setup now seeds the full canonical team.
+
+**Documentation Needs**:
+- [ ] CHANGELOG entry
+- [ ] Note in setup docs that the full canonical team is seeded and stack advisors are appended
+
+### Confidence Assessment
+
+**Model Correctness Confidence**: High — the defects are reproduced (dogfood), and the fix removes a
+duplication rather than adding a model.
+
+**Assumptions**:
+1. Source discovery reliably resolves the framework root during setup. — **Validation**: already relied
+   on for templates; covered by `setup-source-discovery` tests.
+2. Appending advisors to the canonical 8 is preferable to substitution. — **Validation**: matches the
+   framework's stated 8-member model; revisit if a stack genuinely needs a core member replaced.
+
+**Uncertainty Areas**: advisor-selection heuristics per stack; whether the Skill and MCP should share a
+single detection module to prevent re-divergence (likely yes — see ADR-015's duplication non-goal).
+
+**Validation Approach**: a setup-fidelity test that runs setup against polyglot fixtures and asserts
+(a) the seeded roster ⊇ the canonical 8 including `pragmatic_enforcer`, (b) all present manifests are
+detected, (c) the datastore is surfaced, (d) generated links resolve.
+
+**Edge Cases**: monorepos with multiple manifests of the same ecosystem; a project that already has a
+customized `members.yml` (must be preserved on re-run).
+
+## Implementation
+
+**Phase 1: Stack detection + generated-link fix**
+* Make `analyzeProject` scan all manifests and report language/framework *sets* + datastore.
+* Fix the `principles.md` path in `conductInitialAnalysis`; add the generated analysis to link validation.
+
+**Phase 2: Canonical team seeding**
+* Change `customizeMembers` to copy the framework's canonical `members.yml` (via source discovery) as the
+  base, then append any stack advisors. Never drop the canonical 8.
+
+**Phase 3: Roster-driven analysis + fidelity test**
+* Generate `initial-system-analysis.md` from the seeded roster.
+* Add the setup-fidelity test (polyglot fixtures; assert canonical-8 ⊆ roster, multi-manifest detection,
+  datastore surfaced, links resolve).
+
+## Alternatives Considered
+
+### Alternative 1: Keep hardcoded members; just add the missing ones
+
+Add `pragmatic_enforcer`/`domain_expert` to the hardcoded list and fix ids.
+
+**Pros:** smallest diff.
+**Cons:** leaves the duplication that caused the drift; the hardcoded list will diverge from
+`members.yml` again the next time the canonical team changes. Treats the symptom, not the cause.
+
+### Alternative 2: Do nothing; document that MCP setup yields a reduced team
+
+**Pros:** zero work.
+**Cons:** ships a silently lossy install that contradicts the docs and breaks pragmatic mode; leaves
+ADR-015's Tier-1 parity claim false.
+
+### Alternative 3: Share one detection/seeding module between the Skill and MCP
+
+Extract setup logic into a shared module both surfaces import.
+
+**Pros:** prevents future MCP↔Skill divergence at the source (the real fix).
+**Cons:** larger refactor; overlaps ADR-015's deferred "consolidate duplication" non-goal. Worth doing,
+but bigger than this ADR — fold into the duplication-consolidation ADR rather than block this fix.
+
+## Pragmatic Enforcer Analysis
+
+**Reviewer**: Pragmatic Enforcer
+**Mode**: Balanced
+
+**Overall Decision Complexity Assessment**:
+This fixes concrete, reproduced defects by *removing* duplicated knowledge (hardcoded team) in favor of
+the canonical source. It adds detection breadth and one test — proportionate. The temptation to
+over-reach (Alternative 3's shared-module refactor) is explicitly deferred.
+
+**Decision Challenge**:
+
+**Proposed Decision**: "Setup seeds the full canonical team from `members.yml`, detects all manifests,
+drives the initial analysis from the roster, and fixes generated links."
+
+**Necessity Assessment**: 8/10 — reproduced defects that ship a lossy install and break pragmatic mode;
+also unblocks ADR-015's parity claim. Present, not speculative.
+
+**Complexity Assessment**: 3/10 — bounded changes to three setup helpers + a fidelity test; reuses
+existing source discovery; no new deps.
+
+**Alternative Analysis**: "Do nothing" and "patch the hardcoded list" were considered; both leave the
+root duplication. The shared-module refactor is the deeper fix but is deferred to avoid scope creep.
+
+**Simpler Alternative Proposal**: Phase 1 (detection + link fix) alone removes the most visible defects
+if Phase 2 must wait; but Phase 2 is the one that fixes the parity root cause and should not be skipped.
+
+**Recommendation**: ✅ Approve decision
+
+**Pragmatic Score**:
+- **Necessity**: 8/10
+- **Complexity**: 3/10
+- **Ratio**: 0.38 *(Target: <1.5 for balanced mode)*
+
+**Overall Assessment**: Appropriate, root-cause fix for current defects; defers the larger refactor
+honestly.
+
+## Validation
+
+**Acceptance Criteria:**
+- [ ] Setup against a polyglot fixture seeds a `members.yml` containing all 8 canonical architects
+  (incl. `pragmatic_enforcer`, `domain_expert`) with canonical ids, plus any appended stack advisors.
+- [ ] All present manifests are detected (Ruby/Rails + JS/Express in the dogfood case) and the datastore
+  is surfaced.
+- [ ] `initial-system-analysis.md` reflects the seeded roster and contains no broken links.
+- [ ] A setup-fidelity test enforces the above and runs under `npm test`.
+- [ ] Re-running setup on a project with a customized `members.yml` preserves it.
+
+**Testing Approach:**
+* Setup-fidelity test over polyglot fixtures (assert roster ⊇ canonical 8, multi-manifest detection,
+  datastore surfaced, links resolve); golden compare the seeded roster to canonical `members.yml`.
+
+## References
+
+* [ADR-015: Reconciling MCP and Skills](./ADR-015-mcp-skills-parity-reconciliation.md) — second tier axis; tracks this as the Tier-1 setup-parity fix
+* [Architecture Review: ADR-015](../../reviews/adr-015-architecture-review.md) — dogfood that surfaced these defects
+* [Structural First-Principles Examination](../../reviews/structural-first-principles-examination.md) — the MCP↔canonical drift theme

--- a/.architecture/reviews/adr-015-architecture-review.md
+++ b/.architecture/reviews/adr-015-architecture-review.md
@@ -1,0 +1,162 @@
+# Architecture Review: ADR-015 (MCP/Skills Parity Reconciliation)
+
+**Review target:** ADR-015 — Reconciling MCP and Skills (Two-Tier Channel Parity), Status: Proposed
+**Date:** 2026-06-16
+**Process:** Full multi-perspective review (ADR-013 orchestrator pattern) — all 8 architecture team
+members dispatched as independent subagents, plus a live dogfood of `setup_architecture`.
+**Pragmatic mode:** Enabled (balanced).
+
+> This review was produced by running the framework on its own ADR — the architecture-review
+> orchestrator dispatched eight specialist subagents in parallel, each reviewing from one lens only.
+
+## Executive Summary
+
+**Consensus verdict: Approve-with-changes — 8 of 8 architects.** No member approved as-is; none
+rejected. The decision's *direction* (a capability-based two-tier model + honest tool naming) is
+endorsed unanimously, but the ADR as written contains two factual inaccuracies and one
+possibly-unnecessary mechanism that must be addressed first. Several corrections make the decision
+**stronger**, not weaker.
+
+The four highest-priority findings (each raised independently by 2–4 members and corroborated by the
+dogfood run):
+
+1. **P1 — The "Tier-1 is genuinely at parity" claim is false.** `setup_architecture` (a declared
+   Tier-1 "full parity" op) diverges: `mcp/index.js:471-548` `customizeMembers` hardcodes a 4–6 member
+   roster, omits `pragmatic_enforcer` and `domain_expert`, uses divergent ids (`security_architect` vs
+   canonical `security_specialist`), and never reads canonical `.architecture/members.yml`. *(Systems,
+   Domain, Maintainability, AI Engineer + dogfood.)*
+2. **P2 — The "MCP has no agent loop / orchestration is architecturally infeasible" rationale is
+   overstated.** The MCP spec's `sampling` lets a server drive nested LLM calls ("agentic behaviors").
+   The accurate — and stronger — claim: MCP servers cannot dispatch the *host's* Agent/Task subagents;
+   Claude Code does not currently expose `sampling`; and even sampling is single-shot/human-gated, not
+   ADR-013's forked parallel fan-out. *(AI Engineer, High.)*
+3. **P3 — The deprecation-alias shim may be YAGNI.** Its removal trigger ("usage signal/telemetry")
+   can never fire for an stdio MCP server with no telemetry, so the "temporary" alias is
+   permanent-by-default. Independent Pragmatic score **0.67** vs the ADR's self-score 0.43. *(Pragmatic
+   Enforcer High; Maintainability, Implementation, Security Med.)*
+4. **P4 — Permission allow-list is in the blast radius, uncounted.** `.claude/settings.json` allow-lists
+   two of the three renamed tools by exact name; renaming silently de-scopes them. *(Security, High;
+   verified.)*
+
+## Dogfood Evidence (setup_architecture)
+
+A live `setup_architecture` run against a fresh Rails+Express fixture produced independent corroboration
+for P1 and exposed setup-specific bugs:
+
+- **Divergent team:** generated 6 members (systems/security/performance/maintainability + javascript/
+  express experts) vs the canonical 8; **omits pragmatic-enforcer and domain-expert**; divergent ids.
+- **Stack misdetection:** reported "Framework: Express" and built `javascript_expert` + `express_specialist`
+  while missing the Rails/Ruby stack entirely (Gemfile present; package manager *was* detected as
+  "bundler" — internally inconsistent). SQLite (Gemfile) not surfaced.
+- **Initial analysis hardcoded to 4 perspectives** (Systems/Security/Performance/Maintainability), not
+  the roster.
+- **Broken generated link:** `initial-system-analysis.md` points to `.architecture/decisions/principles.md`
+  (actual: `.architecture/principles.md`) — ironic post-1.5.4 link cleanup.
+
+These are out of ADR-015's scope but should be filed as a separate setup-fidelity issue/ADR; they prove
+the MCP↔canonical drift is broader than the review tools.
+
+## Individual Perspectives
+
+**Systems Architect — Approve-with-changes.** Root-cause framing (capability property, not bug) is at
+the right altitude. But the tier boundary is drawn on incomplete evidence: `setup_architecture` is also
+divergent yet filed under full parity. Add a second tier axis: "deterministic **and** reads the same
+canonical artifacts." Amend ADR-011's *code-sharing* claim, not just the parity sentence.
+
+**Domain Expert — Approve-with-changes.** The split names a real domain concept honestly (one term had
+denoted two operations). But the vocabulary isn't yet a coherent ubiquitous language: "channel" is
+overloaded (ADR-011 = distribution; ADR-015 title = capability), and "Tier-2" denotes *both* the
+orchestrated op and its hollow scaffold — reintroducing one-term-two-meanings one level up. Retitle to
+"Two-Tier **Capability** Model"; define tiers by domain *outcome*, not mechanism; reserve "channel" for
+distribution.
+
+**Security Specialist — Approve-with-changes.** Rename is security-positive (kills a name-spoofing
+trap). But `.claude/settings.json` allow-lists `specialist_review` and `start_architecture_review` by
+exact name; after rename the deprecated alias is the only *pre-approved* path — inverting trust (the
+safer-named tool prompts; the legacy name runs silently). Add settings.json to blast radius; never leave
+a deprecated name as the only allow-listed path; add a stderr deprecation log for real evidence; bump
+semver + CHANGELOG "BREAKING (aliased)".
+
+**Maintainability Expert — Approve-with-changes.** Honest naming is a durable win and the tier rule is a
+real invariant. But the ADR relabels without reducing the actual liability: MCP and Skills are two
+independent reimplementations sharing **zero** code; Tier-1 duplication persists and must be maintained
+in parallel forever (already drifting — see setup). Add an explicit non-goal ("does not consolidate the
+duplication"), a parity smoke-test driven by canonical `members.yml`, a version-bound alias-removal
+default, and a CI grep that old names appear only in CHANGELOG/ADRs.
+
+**Performance Specialist — Approve-with-changes.** Narrow lens, stated honestly. The tier boundary is
+also a *cost* boundary the ADR never names: Tier-2 orchestration fans out N subagents (most expensive op
+in the framework); a scaffold is ~free. Name the asymmetry; add "when to use scaffold vs orchestration"
+routing guidance; sub-label the three Tier-2 ops by cost (N-subagent / 1-subagent / 1-pass).
+
+**Implementation Strategist — Approve-with-changes.** Reversibility/sequencing are honest. But the
+deprecation window has no anchor version ("one minor" from undefined base), the removal trigger is
+unactionable (no telemetry), the ADR-011 amendment mechanics are unspecified (where/Status change?), and
+it assumes the ADR-012 Phase-5 smoke test is live when it's gated behind a manual fallback. Pin versions;
+make removal time-based ("absence of objection = remove"); specify the annotation mechanics; add a
+prerequisite to confirm the MCP-capability assumption and the smoke test before Phase 1.
+
+**AI Engineer — Approve-with-changes.** The agent-UX outcome is right (the pointer-in-payload pattern is
+correct LLM-orchestration design). But the central rationale is factually overstated against the MCP
+spec (sampling enables server-side agentic behavior). Reframe to the accurate, *stronger* claim — and
+note that even sampling (single-shot, human-gated) ≠ ADR-013 fan-out, which is the durable reason parity
+is out of reach. Also flags the `setup_architecture` Tier-1 divergence as the same family of bug.
+
+**Pragmatic Enforcer — Approve-with-changes (independent).** Did not rubber-stamp the self-analysis.
+The coherence fix is needed now; the alias shim is not — it defends an unevidenced audience with an
+unfireable removal trigger and becomes permanent-by-default. Recommends **dropping the alias + Phase 3**
+and doing a one-shot rename, and **seriously elevating Alternative 2 (delete the three template tools)**
+since the host can produce the same template inline. Also: justify rename vs a cheaper description-only
+fix. **Independent score: Necessity 6 / Complexity 4 / Ratio 0.67** (vs self 0.43); stripped of the
+alias, the reduced decision earns ~0.29.
+
+## Collaborative Discussion (Cross-Cutting Synthesis)
+
+- **The decision is right; the justification and scope need work.** Every member endorses two tiers +
+  honest naming. The corrections (P1, P2) remove false claims that would have undermined the ADR on
+  inspection — fixing them is net-strengthening.
+- **The real disease is duplication, not naming.** Maintainability + Systems + the dogfood converge:
+  MCP and Skills are independent reimplementations that already drift (setup roster). ADR-015 should
+  explicitly scope this out (non-goal) rather than imply it's fixed, and add a parity test so Tier-1
+  claims become *enforced*, not asserted.
+- **Simplicity tension on the alias.** Pragmatic/Maintainability/Implementation lean "drop the alias";
+  Security leans "be careful" — but Security's concern is *resolved by removing the alias* (no
+  name-divergence window). The synthesis favors a one-shot rename with a CHANGELOG breaking note, with
+  Alternative 2 (delete) elevated as a live option for maintainer ratification.
+
+## Prioritized Recommendations
+
+**Must-fix before acceptance (factual/correctness):**
+1. (P1) Correct the Tier-1 parity claim; add the second axis ("deterministic **and** reads canonical
+   artifacts"); mark `setup_architecture` parity as *target, not actual*; file the setup divergence as
+   tracked follow-up + add a canonical-driven parity smoke test as acceptance criterion.
+2. (P2) Reframe the agent-loop rationale to: no host-subagent dispatch; Claude Code doesn't expose
+   `sampling`; sampling ≠ ADR-013 fan-out. Update Assumption #1 to the verified result.
+3. (P4) Add `.claude/settings.json` to the blast radius; migrate allow-list entries in lockstep; note
+   `pragmatic_enforcer` is not allow-listed.
+4. Add the 9th shipped tool `get_implementation_guidance` to the tier table (Tier-1).
+5. Amend ADR-011's "95% code-sharing/thin-wrapper" framing too (it describes wrapper→npm, not
+   MCP↔Skills, which share zero code).
+
+**Should-fix (design/clarity — includes the ratification call):**
+6. (P3) Drop the deprecation alias + Phase 3; do a one-shot rename with CHANGELOG "BREAKING"; OR pin a
+   concrete removal version with "absence of objection = remove." Elevate Alternative 2 (delete) to a
+   ratification option. Reconcile the self Pragmatic score with the panel's 0.67.
+7. (P5) Retitle to "Two-Tier Capability Model"; reserve "channel" for distribution; define tiers by
+   outcome; add a glossary mapping operation → tier → orchestrated form → scaffold form.
+8. (P7) Name the Tier-2 cost asymmetry; add scaffold-vs-orchestration routing guidance + per-op cost
+   sub-labels.
+
+**Nice-to-have (process):**
+9. Add a non-goal: this ADR does not consolidate MCP/Skills duplication (deferred).
+10. Codify the ADR-amendment convention (append-only `> Amended by ADR-NNN` annotation; Status stays
+    Accepted). Add a CI grep guard that old tool names appear only in CHANGELOG/ADRs.
+11. Don't assume ADR-012 Phase-5 smoke test is live; verify or add a direct `claude --plugin-dir ./`
+    tool-load check.
+
+## Overall Recommendation
+
+**Approve-with-changes.** Accept the two-tier direction. Apply the must-fix corrections (P1, P2, P4,
+#4, #5) before moving the ADR to Accepted, and ratify the alias/delete decision (P3). The review
+*increased* confidence in the core decision while catching two claims that would not have survived
+scrutiny.

--- a/.architecture/reviews/adr-016-architecture-review.md
+++ b/.architecture/reviews/adr-016-architecture-review.md
@@ -1,0 +1,151 @@
+# Architecture Review: ADR-016 (Setup Fidelity — Canonical Sources)
+
+**Review target:** ADR-016 — "Setup Must Derive Team and Stack from Canonical Sources," Status: Proposed
+**Date:** 2026-06-16
+**Process:** Full multi-perspective review (ADR-013 orchestrator) — all 8 architects dispatched as
+independent subagents; claims verified against `mcp/index.js`.
+**Pragmatic mode:** Enabled (balanced).
+
+## Executive Summary
+
+**Consensus: Approve-with-changes — 7 of 8; Performance: Approve (narrow lens).** The decision's
+direction — seed the team from the canonical `members.yml` instead of a hardcoded list — is endorsed
+unanimously as the correct root-cause fix. But the review found **four factual errors in the ADR** (all
+verified in code) that materially change its risk, effort, and completeness, plus scope and
+vocabulary issues.
+
+**Verified factual corrections (must-fix):**
+
+1. **F1 — Setup does NOT use source-discovery.** The ADR's load-bearing risk claim ("reuses the proven
+   source-discovery path… already relied on for templates… low marginal risk," Complexity 3/10) is
+   false. `mcp/index.js` setup copies from `path.resolve(__dirname, '..')` via `fs.copy` (line 229) and
+   never references `setup-source-discovery.js`. Wiring discovery into MCP setup is **new work and a new
+   failure mode**, not a marginal extension. *(Systems, Implementation, AI Engineer — High; verified.)*
+2. **F2 — Setup never generates subagents.** Setup seeds `members.yml` but never runs the generator, and
+   `agents/*.md` live at repo root (not copied into the target). A fresh install therefore has the team
+   YAML but **zero dispatchable subagents** — reviews and pragmatic mode cannot run end-to-end. The
+   ADR's "subagent generator and Skills unaffected / pragmatic mode works out of the box" is false for
+   new installs. *(AI Engineer — High; verified: no `generateAll` call.)*
+3. **F3 — Re-run is impossible today; the "preserves customized members.yml" guarantee is unbuilt.**
+   Setup **aborts** when `.architecture` exists (line 206). There is no merge path, so the ADR's
+   "non-destructive re-run preserves customizations" is neither current behavior nor built by any phase,
+   and it hides a real fork (preserve → fix never reaches existing installs; reseed → loses edits).
+   *(Implementation — High; Maintainability — Med; verified.)*
+4. **F4 — The drift is 4 missing members, not 2, plus a mislocated file.** `customizeMembers` (line 394)
+   hardcodes 4 base members (and `security_architect`, not canonical `security_specialist`), omitting
+   **`domain_expert`, `implementation_strategist`, `ai_engineer`, and `pragmatic_enforcer`**.
+   Separately, `customizePrinciples` writes principles to `decisions/principles.md` (line 525) — the
+   *file is mislocated*, not merely linked wrong (canonical: `.architecture/principles.md`; 3 reference
+   sites at 525/703/804). *(Pragmatic, Maintainability, AI Engineer; verified.)*
+
+## Individual Perspectives
+
+**Systems Architect — Approve-with-changes.** Right instinct (one canonical source). But the ADR rests
+on F1 (setup doesn't use discovery), so its risk/effort is understated; needs an explicit
+**discovery-failure policy** (fail loudly, never fall back to a partial hardcoded roster, or drift
+returns). Also: `principles.md`/templates are *also* hardcoded inline — same root cause, fix or scope
+out. Define the `analyzeProject` output as a named contract (languages[]/frameworks[]/datastore[]) so
+the three consumers don't re-diverge. Advisor ids need a canonical-precedence/uniqueness rule.
+
+**Domain Expert — Approve-with-changes.** "advisor" is load-bearing but undefined; "specialist" is
+overloaded (core `*_specialist` vs a stack "Rails specialist"). Add a Domain Vocabulary block:
+**member** (any entry), **core member** (canonical 8, invariant floor), **advisor** (appended,
+stack-derived, additive, never substitutes). State whether advisors share the schema and join review
+phases; add id-uniqueness.
+
+**Security Specialist — Approve-with-changes.** Copying `members.yml` from a *discovered* source and
+parsing untrusted manifests are higher-trust ops than the ADR treats them. Add: **validate the copied
+roster** (assert canonical-8 ids incl. `pragmatic_enforcer`; fail closed); **sanitize** manifest-derived
+values (framework/dep names get interpolated into ids and the generated analysis — injection path);
+**bound** manifest scan size/count (DoS); log which `source` (env/plugin/clone) resolved (env var is
+the highest-priority, spoofable resolver).
+
+**Maintainability Expert — Approve-with-changes.** Removes real duplication and the golden test is the
+right guard. But the Skill is **not** fully unaffected (F-adjacent): it copies canonical `members.yml`
+yet its docs encode a stale 6/7-member core (SKILL.md step 4 = 7; customization-guide = 6; checklist =
+"seven"), omitting `implementation_strategist` + `ai_engineer`. Fixing only MCP leaves a doc-level
+second source of truth that re-drifts. Tighten the test from `⊇ canonical-8` to **set-equality on the
+canonical block** (a superset passes even with a wrong-id member, missing the `security_architect`
+drift). Resolve the re-run fork (F3) and define the merge key (`id`).
+
+**Performance Specialist — Approve.** Negligible lens (one-shot, root-scoped). Only ask: bound detection
+to root-only (don't recurse into `node_modules`/`vendor`); keep fidelity-test fixtures as minimal stub
+manifests.
+
+**Implementation Strategist — Approve-with-changes.** The plan rests on F1 (false prerequisite — add a
+Phase 0 to wire `discoverSource` into MCP setup) and F3 (re-run preservation is unbuilt and currently
+blocked by the line-206 abort — give it its own phase + test or drop it). Phase 2 must **replace** the
+hardcoded `writeFile` (line 467), not append. The Skill↔MCP divergence needs a coordination contract:
+run the fidelity test against **both** surfaces, or scope the Skill out explicitly.
+
+**AI Engineer — Approve-with-changes.** F2 is the central gap: seeding YAML without generating
+`agents/*.md` (and without seeding a `config.yml` carrying `pragmatic_mode`) means the team isn't
+dispatchable and "pragmatic mode works out of the box" is unproven. Add: setup runs the generator and
+seeds `config.yml`; assert `agents/pragmatic-enforcer.md` exists post-setup. Add an **observability**
+criterion: setup reports the seeded roster (count + ids), generated subagents, and detected stack +
+datastore, so an operator can trust the install without inspecting files. Fix `principles.md` at its
+source (mislocated, 3 sites).
+
+**Pragmatic Enforcer — Approve-with-changes (independent: Necessity 7 / Complexity 5 / Ratio 0.71,
+disagrees with self-score 0.38).** The core (seed-from-canonical) is justified — Alternative 1 (patch
+the hardcoded list) would need ~4 members + id fixes and re-drifts. But the ADR **bundles scope creep**:
+datastore-surfacing has no named consumer (YAGNI), and dynamic roster-driven analysis regeneration is
+the heaviest part for the least defect value (the link bug is one line). Trim to: canonical seed +
+multi-valued framework (so no masking) + principles/link fix + generator + Skill-doc reconcile. Relax
+the golden test to canonical-block equality (less brittle than full golden). Self-score Complexity 3
+undercounts the bundled work.
+
+## Collaborative Discussion (Synthesis)
+
+- **The decision is right; the ADR's description of current reality was wrong.** F1–F4 all stem from the
+  ADR being written from the dogfood symptom + a partial read, asserting a reuse ("source-discovery,
+  templates") that doesn't exist and a completeness ("subagents/pragmatic work") that the new-install
+  path never delivers. Correcting them makes the ADR bigger but honest.
+- **"Seed the YAML" is necessary but not sufficient.** Three things must co-occur for a fresh install to
+  actually function: (1) seed canonical `members.yml`, (2) **generate `agents/*.md`** from it, (3) seed
+  `config.yml` with `pragmatic_mode`. F2 means the ADR currently specifies only (1).
+- **Drift is relocated unless the Skill is included.** MCP and the Skill are two setup paths; the Skill's
+  copy is right but its docs aren't. The cheap hedge (until the shared-module ADR) is: fix the Skill
+  docs to reference the canonical file, and run the fidelity test against both surfaces.
+- **Trim the scope.** The bug is "wrong team + masked stack + mislocated principles." Datastore-surfacing
+  and dynamic analysis regeneration exceed it; defer them.
+
+## Prioritized Recommendations
+
+**Must-fix (correctness):**
+1. (F1) Correct the premise; add **Phase 0: wire `discoverSource` into MCP setup**, replacing the
+   `__dirname` copy. Add a **discovery-failure policy** (fail loudly; never partial-seed).
+2. (F2) Add to the Decision: setup **generates `agents/*.md`** from the seeded roster and **seeds
+   `config.yml` with `pragmatic_mode`**; acceptance: `agents/pragmatic-enforcer.md` exists + config has
+   the block.
+3. (F3) Resolve re-run: either build preserve+reseed-canonical-block (own phase + idempotency test,
+   merge key = `id`) or **drop the guarantee** and state setup still aborts on an existing `.architecture`
+   (existing installs out of scope).
+4. (F4) Correct the count to **4 missing members**; fix `principles.md` **location** (write to
+   `.architecture/principles.md`) at all 3 sites, not just the link.
+5. Phase 2 must **replace** the hardcoded member write (line 467), not append.
+
+**Should-fix (design/clarity):**
+6. (Maintainability) Reconcile the **Skill docs** (SKILL.md / customization-guide / checklist) to
+   reference the canonical roster by file; run the fidelity test against **both** MCP and Skill, or
+   scope the Skill out explicitly.
+7. (Maintainability/Pragmatic) Test asserts the **canonical block = canonical ids exactly** (catches
+   id-drift) + zero-or-more advisors; avoid brittle full-golden.
+8. (Domain) Add a **Vocabulary** block (member / core member / advisor); advisor id-uniqueness;
+   stop calling advisors "specialists."
+9. (Security) Validate the copied roster (fail closed); sanitize manifest-derived values; bound the
+   scan; log the resolved source.
+10. (Pragmatic) **Trim scope**: defer datastore-surfacing (no consumer) and dynamic analysis
+    regeneration; keep multi-valued framework + the one-line link/location fix.
+
+**Nice-to-have:**
+11. (AI Engineer) Setup **reports** the seeded roster + generated subagents + detected stack
+    (observability).
+12. (Systems/Performance) Define the `analyzeProject` output contract once; bound detection to root-only.
+
+## Overall Recommendation
+
+**Approve-with-changes.** Keep the canonical-seed direction. Before moving to Accepted, apply the
+correctness fixes (F1–F4 + the generator/config gap), reconcile the Skill, and trim the bundled scope.
+The review's net effect: the fix is **larger and more dependency-laden than the ADR claimed**, but also
+**incomplete as written** — seeding YAML alone would have shipped a still-broken install.

--- a/.architecture/reviews/structural-first-principles-examination.md
+++ b/.architecture/reviews/structural-first-principles-examination.md
@@ -1,0 +1,282 @@
+# Structural Examination: First Principles
+
+> A critical look at the *shape* of the AI Software Architect framework — not its features, but
+> whether its fundamental structure is justified. Companion to the feature inventory; written to be
+> disagreed with.
+>
+> **Date:** 2026-06-09
+> **Method:** Full-surface inventory (skills, MCP, agents, hooks, tools, artifacts, docs) →
+> first-principles interrogation of each structural choice.
+
+---
+
+## Thesis
+
+**This is a methodology wearing a framework's clothes.**
+
+~80% of the value is a *way of thinking* — eight specialist lenses, senior-thinking checklists
+(blast radius, reversibility, social cost), pragmatic YAGNI pressure, durable decision records.
+~20% is *code* — validators, a generator, two hooks, a CLI.
+
+The methodology is the product. But it is **packaged, versioned, and distributed like a software
+product** — semver, a plugin, an MCP server, CI matrices, a four-surface delivery story. Most of the
+structural tension in the repo traces back to that single mismatch. A methodology doesn't need four
+delivery surfaces or four version numbers; it needs to be *read, internalized, and invoked*. The code
+parts that genuinely matter are thin wrappers around "ask the model to think this way, in independent
+contexts."
+
+The rest of this document argues that from first principles, then names what's load-bearing and what
+has calcified into surface area.
+
+---
+
+## Seven first-principles questions
+
+### 1. Is the *persona* the load-bearing primitive, or the *dimension*?
+
+The framework reifies eight architects (`members.yml` → `agents/*.md`). But one model does not host
+eight minds. "Be the security specialist" yields the model's security knowledge through a persona
+filter. The real signal of a multi-perspective review is **coverage of dimensions** — did we examine
+security, performance, maintainability, blast radius? — not the existence of named characters.
+
+The persona buys two real things: (a) **independent contexts** when dispatched as separate subagents
+(ADR-013), which genuinely reduces anchoring and forces breadth; (b) narrative identity, which is
+mostly flavor. The danger is mistaking (b) for the value. If personas were collapsed to a checklist
+of review dimensions run in parallel sub-contexts, almost no signal would be lost and a lot of
+maintenance (roster YAML, generator, drift-checks, protection hook) would disappear.
+
+**Question to sit with:** if you deleted the names and kept the dimensions + independent contexts,
+what would actually get worse for the user?
+
+### 2. Four surfaces (Skills + MCP + subagents + hooks) — what does MCP earn?
+
+This is the clearest over-build. Every operation exists as both a Skill and an MCP tool **with
+different behavior**: Skills *orchestrate real subagent reviews*; the MCP equivalents *emit empty
+templates for manual completion*. A user who invokes `start_architecture_review` over MCP gets a
+hollow shell of the same-named Skill. That is not two surfaces serving two audiences — it is one good
+implementation and one inferior duplicate sharing names.
+
+MCP's only first-principles justification is non-Claude MCP clients. But the framework is so
+Claude-centric (skills, subagents, hooks, plugin) that an MCP-only client already gets a degraded
+experience. So MCP carries weight — a 1,800-line `index.js`, its own version, its own test surface —
+to serve an audience the rest of the framework doesn't really serve.
+
+**Question to sit with:** is MCP a product surface, or development archaeology that was never retired?
+
+### 3. "Cross-platform" — real, or aspirational tax?
+
+The framework's canonical-core story (AGENTS.md as platform-neutral truth, CLAUDE.md as the Claude
+layer) is built for three platforms. The actual investment:
+
+- **Claude:** 7 skills, 8 subagents, 2 hooks, plugin, MCP. (Everything.)
+- **Cursor:** 5 static `.mdc` files.
+- **Codex:** "context recognition" — i.e., it reads the docs and hopes.
+
+So "cross-platform" is "Claude, plus breadcrumbs." Yet the abstraction imposes real, ongoing cost:
+the AGENTS.md/CLAUDE.md split, the instruction-counting machinery built to police it (ADR-005/006),
+and duplicated setup prose across five files. The framework pays cross-platform taxes for a
+single-platform reality.
+
+**Question to sit with:** if Cursor and Codex support were dropped tomorrow, would any real user
+notice — and how much structure would collapse if they did?
+
+### 4. Do the artifacts serve users, or the framework's own development?
+
+**All 14 ADRs are about the framework's own construction.** Zero document a decision in any domain
+the framework exists to help with. CLI requirements, pragmatic mode, agents.md adoption, instruction
+capacity, skills, the plugin, the orchestrator pattern, setup. The reviews are the same — Claude
+marketplace plugin, skills implementation, feature parity, progressive disclosure.
+
+This is dogfooding, which is healthy. But it means the structure has been shaped by *what the
+framework needed during its own development*, not by what a downstream user's project needs. The
+`comparisons/` directory (148KB of phase-2 results, skills deep-dives, PoC writeups) is R&D notes
+**shipped inside the product**. A user installing this to govern *their* Rails app inherits the
+framework's own development diary.
+
+**Question to sit with:** what in `.architecture/` would a brand-new adopter actually want present on
+day one, versus what is the author's lab notebook?
+
+### 5. Instruction-capacity governance — proportional cure, or Goodhart?
+
+There is real machinery here: an instruction counter, a counting-methodology doc, CI enforcement, and
+the three-tier doc split (AGENTS ≤150 / CLAUDE ≤30 / agent_docs on demand). The underlying concern —
+context dilution degrades instruction-following — is legitimate and well-observed.
+
+But a regex that counts "commands, conditionals, procedures, guidelines" is a *proxy*. The real
+failure is the model ignoring or contradicting instructions, which correlates with count only loosely.
+150 well-organized, non-conflicting instructions outperform 80 contradictory ones. Building CI that
+fails a build for crossing a count threshold optimizes the number, not the outcome — the textbook
+shape of a Goodhart trap. The cure has grown its own bureaucracy (a methodology doc *about how to
+count*, metrics tracking) that itself adds surface area.
+
+**Question to sit with:** has anyone measured that staying under 150 actually improves model behavior,
+or is the number self-justifying because it's enforced?
+
+### 6. Protected files — who is protected from whom?
+
+Two hooks block the *agent* from editing `members.yml`, `principles.md`, `config.yml`. The same agent
+is trusted to author ADRs, run architecture reviews, and design systems. The stated reason is drift:
+editing `members.yml` without regenerating `agents/*.md` desyncs source and output.
+
+But that's a **build-system problem** — a generated artifact going stale relative to its source. The
+correct fix is to make generation automatic (regenerate on change, or treat `agents/*.md` as a pure
+build product never committed). Blocking edits is a guardrail compensating for a missing build step,
+and it encodes a distrust that sits oddly against everything else the agent is trusted to do.
+
+**Question to sit with:** if `agents/*.md` regenerated automatically, would the protection hook have
+any remaining reason to exist?
+
+### 7. Is it a framework or a methodology — and does the packaging fight its nature?
+
+Return to the thesis. The four-way version drift is the tell: **plugin 1.5.4, MCP 1.3.0, tools 1.0.0,
+config/CLAUDE 1.2.0.** Four components, four versions, one product, no single answer to "what version
+am I running." That is what happens when a methodology is forced into software's release model: the
+parts version independently because they were never really one shippable unit — they're facets of an
+idea that got `package.json`s.
+
+A methodology's "release" is a revised way of thinking. This one's releases are CI-validated artifact
+bumps. The mismatch is the root cause feeding questions 2–6: the multi-surface duplication, the
+artifact sprawl, the counting bureaucracy, and the version chaos are all symptoms of packaging a
+*practice* as a *product*.
+
+---
+
+## What is genuinely load-bearing
+
+Be fair: the value is real and concentrated. Three things carry the framework.
+
+1. **Subagent review orchestration (ADR-013).** Dispatching independent sub-contexts for
+   multi-dimension review is the one place the "multi-agent" claim cashes out into real signal:
+   parallel coverage, reduced anchoring. This is the product.
+2. **Senior-thinking scaffolds.** Blast radius, reversibility, sequencing, social cost, confidence —
+   these checklists are high-quality prompting structure that reliably improves the *shape* of an
+   AI's architectural reasoning. (`principles.md` belongs here too.)
+3. **Pragmatic guard / YAGNI pressure.** A direct, well-aimed counter to the LLM's strong bias toward
+   over-building. Conceptually the most original part.
+
+The clean engineering — `members.yml` as single source, generated subagents, drift detection — is
+good *craft*. The question (per #1 and #6) is whether the thing being engineered needs to exist.
+
+---
+
+## What has calcified into surface area
+
+| Item | Verdict | First-principles reason |
+|---|---|---|
+| MCP server | **Retire or fully merge** | Inferior duplicate of Skills; serves an audience the framework doesn't otherwise serve (#2) |
+| Cross-platform abstraction | **Demote to honest "Claude-first"** | Real cost, notional benefit; Cursor/Codex are breadcrumbs (#3) |
+| `comparisons/` (148KB) | **Move out of shipped product** | Author's R&D diary, not user-facing (#4) |
+| Instruction-count CI gate | **Keep, but see stress-test** | Critique softened — research-backed and self-policed (#5, revised below) |
+| Protection hooks | **Keep, but see stress-test** | Critique partly misfired — drift is handled, hooks guard source not output (#6, revised below) |
+| Four version numbers | **✅ FIXED** | Unified to 1.5.4 across all 8 sources + added `version-check` guard (CI-enforced). ADR-011 commitment now honored. |
+| `CLAUDE-example.md` | **Delete** | Documents an unrelated project ("Agentic" Ruby gem) |
+| `.ai-assistants/` | **Delete** | Empty; dead directory |
+| `docs/` (untracked) | **Decide: vendor properly or remove** | Claude Code *platform* docs sitting untracked in repo root |
+| 5 overlapping setup docs | **Consolidate** | Same 6-step process duplicated; one retired doc still shipping |
+
+---
+
+## Stress test: what the recorded rationale says back
+
+The critique above was written before reading the ADRs it names. Read honestly, the framework's own
+decision records defend some of these choices well and expose others as worse than first stated. In
+the spirit of the framework (confident updating on evidence), here is the accounting.
+
+### Critiques that get *weaker*
+
+**#5 Instruction counting — overreached.** ADR-005 grounds the ~150-instruction limit in external
+research (HumanLayer), not invention. More tellingly, the framework's *own* Pragmatic Enforcer
+reviewed ADR-006 and flagged exactly the over-engineering I did — it pushed back on a 6-file split and
+forced consolidation to 2-3 files, with a documented "split further only when a file exceeds 300 lines"
+trigger. Success metrics include *user-reported effectiveness*, not just the count. This is not blind
+Goodharting; it's a proxy used with awareness of its limits. **Revised verdict:** the CI gate is
+defensible. The fair residual concern is narrow — *failing a build* on a proxy is still stronger
+enforcement than the proxy's confidence warrants; advisory warning would lose little. Minor, not
+structural.
+
+**#6 Protection hooks / drift — partly misfired.** Two errors in my original reasoning. First, the
+protection hook guards `members.yml`/`principles.md`/`config.yml` — the *source* files — not the
+generated `agents/*.md`. So it's about preventing unreviewed changes to sources of truth, not about
+drift. Second, ADR-012 *explicitly considered* my proposed fix (runtime/auto-generation, Alternative 3)
+and rejected it for a concrete platform constraint: Claude Code plugins load `agents/*.md` statically
+at install; there is no install-time codegen hook. Drift is caught by a CI golden-file snapshot, which
+is the correct mechanism. **Revised verdict:** withdrawn. The design is sound and the alternative I
+proposed was already evaluated and declined for a real reason.
+
+### Critiques that get *stronger*
+
+**#7 Version drift — this is a broken commitment, not an inconsistency.** ADR-011 ("Architectural
+Decision (Regardless of Path)") commits in writing: *"Single version number shared across all
+channels. Automated release pipeline: git tag → npm publish → Skills update → marketplace sync.
+Prevents version drift and user confusion."* The verified reality — plugin `1.5.4`, MCP `1.3.0`, tools
+`1.0.0`, config/CLAUDE `1.2.0` — means the single-version commitment was made and then broken, and the
+automated pipeline that was supposed to enforce it either was never built or has stopped running. This
+is no longer a smell; it's a named, accepted decision that the codebase contradicts. **Sharpened
+verdict:** highest-priority fix, because it's the framework failing its own recorded standard.
+
+**#2 MCP/Skills divergence — the parity claim is provably false.** ADR-011's thin-wrapper architecture
+rests on "All channels provide identical core features" and "95%+ code sharing." But the inventory
+shows the MCP `start_architecture_review`/`specialist_review` tools emit *empty templates*, while the
+Skills of the same name *orchestrate real subagent reviews* (ADR-013). ADR-012 then bundled Skills,
+subagents, hooks, and MCP into one plugin — putting both behaviors in the same install without
+reconciling them. So "feature parity across all channels" is contradicted by the channels' own code: a
+user gets a real review via the Skill and a hollow shell via the MCP tool of the same name. **Sharpened
+verdict:** confirmed and load-bearing — the framework's central distribution claim doesn't hold.
+
+### New finding the ADRs surface
+
+**The maintainer overrode the framework's own unanimous advice — and that's the most honest thing in
+the repo.** ADR-011 records that the 8-architect review *unanimously* recommended Path B (validate
+demand via enhanced GitHub presence before a marketplace push). The maintainer chose Path A (immediate
+marketplace) anyway, and documented the disagreement in full rather than rewriting the record. Two
+readings, both true:
+
+- *For the thesis (#1):* when a real, costly decision arrived, the eight personas lost to one human's
+  judgment. The personas produced a recommendation; they did not produce the decision. That is
+  evidence the value is the *lens*, not the *vote* — a committee of one model's personas shouldn't be
+  mistaken for independent stakeholders with authority.
+- *For the framework's credibility:* preserving a recorded loss for your own process is exactly the
+  discipline ADRs exist to enforce. The framework passed its hardest test — being used against its
+  author's preference and surviving the disagreement in writing. That is genuinely to its credit.
+
+### Net effect on the thesis
+
+The thesis holds, slightly chastened. "Methodology wearing a framework's clothes" is still the best
+description — but the framework parts are more deliberate than a first pass suggests (the ADRs show
+real engineering judgment, self-critique via the Pragmatic Enforcer, and honest record-keeping). The
+strongest evidence for the thesis is no longer "the structure looks over-built"; it is concrete and
+narrower: **a written single-version commitment broken four ways, and a written feature-parity claim
+the channels' own behavior contradicts.** Those two are the framework failing its own recorded
+standards — which is a sharper, more actionable indictment than "too many surfaces."
+
+## Where first principles point
+
+Not a plan — a direction, to be argued before acting:
+
+1. **Name what it is.** If it's a methodology, lead with that: principles + lenses + checklists as the
+   product, code as the convenience layer. This dissolves most of the tension below it.
+2. **Collapse to one surface.** Skills + subagents + hooks via the plugin is the real product.
+   Everything an operation needs should have exactly one implementation.
+3. **Separate the lab from the product.** The framework's own ADRs, reviews, and comparisons are its
+   development history — valuable, but not what a user installs into their project. Split "framework
+   self-governance" from "what gets scaffolded into a target repo."
+4. ~~**Fix the version commitment first.**~~ ✅ **Done.** Unified all 8 framework/MCP version strings to
+   1.5.4 and added a `version-check` command + CI-enforced consistency test (`tools/lib/version-consistency.js`,
+   `tools/test/version-consistency.test.js`) — the per-file guard the ADR-011 pipeline was meant to provide.
+5. **Reconcile MCP and Skills, or stop claiming parity.** Either make the MCP review tools orchestrate
+   real analysis (match the Skills), or drop the "identical features across all channels" claim and
+   document MCP as the template/programmatic surface it actually is. The current state — same names,
+   different behavior, in one plugin — is the coherence gap most likely to burn a user.
+6. **(Minor) Soften the instruction-count gate to advisory.** The limit is sound; *failing a build* on
+   a regex proxy is firmer than the proxy earns. Warn, don't block.
+
+---
+
+## One question above the rest
+
+Strip the framework to its irreducible core and you have: *a curated set of architectural lenses and
+senior-thinking checklists, applied to a target by an LLM running in independent contexts, producing
+durable decision records.* Everything else — MCP, cross-platform, instruction counting, protection
+hooks, four versions — is scaffolding around that core.
+
+**Is the scaffolding holding the core up, or holding it down?**

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Architecture documentation tools and frameworks",
-    "version": "1.5.4"
+    "version": "1.6.0"
   },
   "plugins": [
     {
       "name": "ai-software-architect",
       "source": "./",
       "description": "AI-powered architecture documentation framework with ADRs, reviews, and pragmatic mode",
-      "version": "1.5.4",
+      "version": "1.6.0",
       "author": {
         "name": "AI Software Architect Project"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-software-architect",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "AI-powered architecture documentation framework with ADRs, reviews, and pragmatic mode",
   "author": {
     "name": "AI Software Architect Project"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,9 +19,7 @@
       "mcp__ai-software-architect__create_adr",
       "mcp__ai-software-architect__get_architecture_status",
       "mcp__ai-software-architect__list_architecture_members",
-      "mcp__ai-software-architect__setup_architecture",
-      "mcp__ai-software-architect__specialist_review",
-      "mcp__ai-software-architect__start_architecture_review"
+      "mcp__ai-software-architect__setup_architecture"
     ],
     "deny": [],
     "ask": []

--- a/.github/workflows/claude-code-tests.yml
+++ b/.github/workflows/claude-code-tests.yml
@@ -22,6 +22,10 @@ jobs:
         working-directory: tools
         run: npm ci
 
+      - name: Install MCP dependencies
+        working-directory: mcp
+        run: npm install --prefer-offline
+
       - name: Lint JSON config files
         run: |
           for f in \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,9 +409,9 @@ The framework works with any AI assistant that can:
 
 ## Version Information
 
-**Framework Version**: 1.2.0
+**Framework Version**: 1.5.4
 **Documentation Version**: 2.0.0 (Progressive Disclosure - ADR-006)
-**MCP Server Version**: 1.2.0
+**MCP Server Version**: 1.5.4
 **Last Updated**: 2025-12-04
 **Maintained By**: AI Software Architect Framework Contributors
 **Repository**: https://github.com/codenamev/ai-software-architect

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,9 +409,9 @@ The framework works with any AI assistant that can:
 
 ## Version Information
 
-**Framework Version**: 1.5.4
+**Framework Version**: 1.6.0
 **Documentation Version**: 2.0.0 (Progressive Disclosure - ADR-006)
-**MCP Server Version**: 1.5.4
+**MCP Server Version**: 1.6.0
 **Last Updated**: 2025-12-04
 **Maintained By**: AI Software Architect Framework Contributors
 **Repository**: https://github.com/codenamev/ai-software-architect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ ADR-011 committed to "a single version number shared across all channels," but t
 
 - Left intentionally independent (distinct version concepts, not channels): `tools/package.json` (internal `architecture-tools` package), `config.yml` `architecture_version` (the target project's architecture version), and AGENTS.md "Documentation Version" (doc-structure version per ADR-006).
 
+#### Setup fidelity ([ADR-016](.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md))
+`setup_architecture` produced a divergent install. It now derives outputs from canonical sources instead of hardcoded logic:
+- **Team:** preserves the copied canonical `members.yml` (all 8 architects with correct ids) instead of overwriting it with a hardcoded 4-member list that used `security_architect` and dropped `domain_expert`, `implementation_strategist`, `ai_engineer`, and `pragmatic_enforcer`. Fails closed if the copy is partial.
+- **Subagents:** generates `agents/*.md` from the seeded roster, so the team is actually dispatchable (a fresh install previously had members but no subagents).
+- **Principles:** writes the technology section to the canonical `.architecture/principles.md` and no longer creates the mislocated `.architecture/decisions/principles.md` (fixing a broken generated link).
+- **Stack detection:** multi-valued frameworks (Rails is no longer masked by Express; Rails detected from Gemfile content).
+- **Skill parity:** `setup-architect` SKILL.md now references the canonical 8-member roster (was listing 7).
+- The `ArchitectureServer` class is now importable; added a roster-seeding lib + an end-to-end setup-fidelity test.
+
 ### Added
 
 - **`version-check` governance command + recurrence guard.** `node tools/cli.js version-check` (and `npm run version-check`) verifies one framework version across all eight channel/doc sources and exits non-zero on drift. Backed by `tools/lib/version-consistency.js` and `tools/test/version-consistency.test.js`, whose repository test fails CI on any future drift — the per-file enforcement the ADR-011 release pipeline was meant to provide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,30 @@ All notable changes to the AI Software Architect framework will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.0] - 2026-06-16
+
+### Removed (BREAKING)
+
+#### Three Tier-2 MCP tools removed ([ADR-015](.architecture/decisions/adrs/ADR-015-mcp-skills-parity-reconciliation.md))
+`start_architecture_review`, `specialist_review`, and `pragmatic_enforcer` are removed from the MCP server (~520 lines of `mcp/index.js`). These tools only ever emitted blank templates/frameworks for manual completion — an MCP server has no agent loop and cannot dispatch the host subagents that make a real review (ADR-013); they shared a name with the Skills that *do* run real reviews, which misled users. **Orchestrated reviews and pragmatic enforcement are now plugin/Skills-only** (`architecture-review`, `specialist-review`, and the `pragmatic-enforcer` subagent). The MCP server retains its deterministic Tier-1 tools (`setup_architecture`, `create_adr`, `list_architecture_members`, `get_architecture_status`, `configure_pragmatic_mode`, `get_implementation_guidance`). The same template structures remain available as static files in `.architecture/templates/`. The two removed allow-list entries were dropped from `.claude/settings.json`.
+
+**Migration:** use the `architecture-review` / `specialist-review` skills (Claude Code plugin) for reviews. MCP-only clients can read `.architecture/templates/review.md` directly for the template.
+
+### Changed
+
+- **Two-tier capability model ([ADR-015](.architecture/decisions/adrs/ADR-015-mcp-skills-parity-reconciliation.md)).** Operations are classified Tier 1 (deterministic; all channels) or Tier 2 (LLM-orchestrated; plugin/Skills only). [ADR-011](.architecture/decisions/adrs/ADR-011-claude-marketplace-plugin-implementation.md)'s "identical core features across all channels" and "95%+ code sharing" claims are corrected by append-only amendment.
 
 ### Fixed
 
 #### Framework version unified across all channels (ADR-011 single-version commitment)
-ADR-011 committed to "a single version number shared across all channels," but the framework version had drifted four ways: plugin/marketplace `1.5.4`, MCP server (`mcp/package.json` + `mcp/index.js`) `1.3.0`, and `config.yml` / `CLAUDE.md` / `AGENTS.md` `1.2.0`. A user could not answer "what version am I running." All framework/MCP version strings are now `1.5.4`.
+ADR-011 committed to "a single version number shared across all channels," but the framework version had drifted four ways: plugin/marketplace `1.5.4`, MCP server (`mcp/package.json` + `mcp/index.js`) `1.3.0`, and `config.yml` / `CLAUDE.md` / `AGENTS.md` `1.2.0`. A user could not answer "what version am I running." All framework/MCP version strings are unified (now `1.6.0`).
 
 - Left intentionally independent (distinct version concepts, not channels): `tools/package.json` (internal `architecture-tools` package), `config.yml` `architecture_version` (the target project's architecture version), and AGENTS.md "Documentation Version" (doc-structure version per ADR-006).
 
 ### Added
 
 - **`version-check` governance command + recurrence guard.** `node tools/cli.js version-check` (and `npm run version-check`) verifies one framework version across all eight channel/doc sources and exits non-zero on drift. Backed by `tools/lib/version-consistency.js` and `tools/test/version-consistency.test.js`, whose repository test fails CI on any future drift — the per-file enforcement the ADR-011 release pipeline was meant to provide.
+- **ADRs:** [ADR-015](.architecture/decisions/adrs/ADR-015-mcp-skills-parity-reconciliation.md) (MCP/Skills two-tier reconciliation, Accepted) and [ADR-016](.architecture/decisions/adrs/ADR-016-setup-fidelity-canonical-sources.md) (setup must derive team/stack from canonical sources, Proposed), plus the supporting architecture review and structural examination under `.architecture/reviews/`.
 
 ## [1.5.4] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the AI Software Architect framework will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### Framework version unified across all channels (ADR-011 single-version commitment)
+ADR-011 committed to "a single version number shared across all channels," but the framework version had drifted four ways: plugin/marketplace `1.5.4`, MCP server (`mcp/package.json` + `mcp/index.js`) `1.3.0`, and `config.yml` / `CLAUDE.md` / `AGENTS.md` `1.2.0`. A user could not answer "what version am I running." All framework/MCP version strings are now `1.5.4`.
+
+- Left intentionally independent (distinct version concepts, not channels): `tools/package.json` (internal `architecture-tools` package), `config.yml` `architecture_version` (the target project's architecture version), and AGENTS.md "Documentation Version" (doc-structure version per ADR-006).
+
+### Added
+
+- **`version-check` governance command + recurrence guard.** `node tools/cli.js version-check` (and `npm run version-check`) verifies one framework version across all eight channel/doc sources and exits non-zero on drift. Backed by `tools/lib/version-consistency.js` and `tools/test/version-consistency.test.js`, whose repository test fails CI on any future drift — the per-file enforcement the ADR-011 release pipeline was meant to provide.
+
 ## [1.5.4] - 2026-05-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,6 @@ Claude Code optimizes for natural language commands:
 
 ## Version Information
 
-**Framework Version**: 1.2.0
+**Framework Version**: 1.5.4
 **Last Updated**: 2025-12-04
 **Optimized For**: Claude Code with instruction capacity constraints (ADR-005)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,6 @@ Claude Code optimizes for natural language commands:
 
 ## Version Information
 
-**Framework Version**: 1.5.4
+**Framework Version**: 1.6.0
 **Last Updated**: 2025-12-04
 **Optimized For**: Claude Code with instruction capacity constraints (ADR-005)

--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ Choose the right installation method for your workflow:
 | **Dependencies** | Node.js ≥18 (auto) | Node.js ≥18 | None | Traditional: No deps<br>Plugin & MCP: Node auto-managed |
 | **Auto-Updates** | ✅ `/plugin update` | ✅ `npm update` | ❌ Git pull | Plugin & MCP: Auto-update |
 | **Offline Use** | ⚠️ Needs npm | ⚠️ Needs npm | ✅ Full | Traditional: Offline ready |
-| **Core Features** | ✅ All 7 | ✅ All 7 | ✅ All 7 | All methods identical |
+| **Tier-1 Deterministic Tools** | ✅ All 6 | ✅ All 6 | ✅ All 6 | All methods identical |
+| **Tier-2 Reviews / Enforcement** | ✅ Skills | ❌ MCP-only install | ✅ Yes | Plugin & Traditional run reviews |
 | **Advanced Features** | ⚠️ 33% | ⚠️ 33% | ✅ 100% | Traditional most complete |
 | **Input Validation** | ✅ Yes | ⚠️ Basic | ❌ No | Plugin best |
-| **Pragmatic Mode** | ✅ Yes | ✅ Yes | ✅ Yes | All support YAGNI |
+| **Pragmatic Mode** | ✅ Yes | ⚠️ Config only | ✅ Yes | MCP configures; reviews are Tier 2 |
 | **Dynamic Members** | ✅ Yes | ❌ No | ✅ Yes | Plugin & Traditional auto-create |
 | **Recalibration** | ❌ No | ❌ No | ✅ Yes | Traditional only |
 | **Project Analysis** | ✅ Advanced | ✅ Advanced | ⚠️ Basic | Plugin & MCP: Advanced |
@@ -176,13 +177,15 @@ Choose the right installation method for your workflow:
 
 | Feature | Plugin 🆕 | MCP Server | Traditional |
 |---------|----------|------------|-------------|
-| Setup Architecture | ✅ | ✅ | ✅ |
-| Create ADR | ✅ | ✅ | ✅ |
-| Architecture Review | ✅ | ✅ | ✅ |
-| Specialist Review | ✅ | ✅ | ✅ |
-| List Members | ✅ | ✅ | ✅ |
-| Get Status | ✅ | ✅ | ✅ |
-| Pragmatic Mode (YAGNI) | ✅ | ✅ | ✅ |
+| Setup Architecture (Tier 1) | ✅ | ✅ | ✅ |
+| Create ADR (Tier 1) | ✅ | ✅ | ✅ |
+| List Members (Tier 1) | ✅ | ✅ | ✅ |
+| Get Status (Tier 1) | ✅ | ✅ | ✅ |
+| Configure Pragmatic Mode (Tier 1) | ✅ | ✅ | ✅ |
+| Implementation Guidance (Tier 1) | ✅ | ✅ | ✅ |
+| Architecture Review (Tier 2) | ✅ Skills | ❌ MCP tool | ✅ |
+| Specialist Review (Tier 2) | ✅ Skills | ❌ MCP tool | ✅ |
+| Pragmatic Enforcement (Tier 2) | ✅ Subagent | ❌ MCP tool | ✅ |
 | Dynamic Member Creation | ✅ | ❌ | ✅ |
 | Recalibration Process | ❌ | ❌ | ✅ |
 | Initial System Analysis | ✅ | ✅ | ✅ |
@@ -193,6 +196,8 @@ Choose the right installation method for your workflow:
 **Legend**: ✅ Fully supported, ⚠️ Partially supported, ❌ Not supported, N/A Not applicable
 
 **Note**: The Plugin bundles the same npm package as the MCP Server option, plus the seven skills, generated subagents, and ADR-validation hook as a single install unit.
+
+**Two-tier capability model** (see [ADR-015](.architecture/decisions/adrs/ADR-015-mcp-skills-parity-reconciliation.md)): Tier-1 operations are deterministic file/config tasks available on every channel, including the MCP server. Tier-2 capabilities — orchestrated architecture reviews, specialist reviews, and pragmatic enforcement — require LLM reasoning and are delivered only through the plugin/Skills (`architecture-review`, `specialist-review`, and the `pragmatic-enforcer` subagent), not as MCP tools. The Plugin gets Tier 2 via its bundled Skills; an MCP-only install does not.
 
 See [Feature Parity Analysis](.architecture/reviews/feature-parity-analysis.md) for detailed comparison.
 

--- a/USAGE-WITH-CLAUDE-PLUGIN.md
+++ b/USAGE-WITH-CLAUDE-PLUGIN.md
@@ -215,18 +215,23 @@ Claude Code Plugin System
          ↓
 npx ai-software-architect (delegates to npm package)
          ↓
-MCP Server Tools (setup, ADRs, reviews, etc.)
+MCP Server Tier-1 Tools (setup, ADRs, status, etc.)
+         +
+Bundled Skills/Subagents (reviews, pragmatic enforcement — Tier 2)
 ```
 
 **Key points**:
 - The plugin itself is just configuration (manifest + MCP config)
-- All functionality comes from the `ai-software-architect` npm package
-- 100% code sharing with MCP Server installation method
+- Tier-1 deterministic tools come from the `ai-software-architect` npm package
+- Tier-2 capabilities (orchestrated reviews, specialist reviews, pragmatic
+  enforcement) come from the bundled Skills and `pragmatic-enforcer` subagent —
+  these are not MCP tools
+- 100% code sharing with the MCP Server install for Tier-1 tools
 - Updates to the npm package automatically benefit plugin users
 
 This design means:
 - Minimal maintenance burden
-- Guaranteed feature parity with MCP Server
+- Tier-1 parity with the MCP Server install, plus Tier-2 reviews via Skills
 - Reliable updates
 - Small download size
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -144,8 +144,13 @@ Add this to your Cursor settings (`settings.json`):
 
 3. **Start using the framework**:
    - Create ADRs: "Use create_adr to document our database choice"
-   - Run reviews: "Use start_architecture_review for version 1.0.0"
-   - Get specialist input: "Use specialist_review with Security Architect for our API"
+   - List your team: "Use list_architecture_members"
+   - Check status: "Use get_architecture_status"
+
+   > **Note**: Orchestrated architecture reviews and pragmatic enforcement are
+   > **not** MCP tools. Run them via the plugin/Skills instead (the
+   > `architecture-review` and `specialist-review` skills and the
+   > `pragmatic-enforcer` subagent). See [Two-Tier Capability Model](#two-tier-capability-model).
 
 ### For Other AI Assistants
 
@@ -158,9 +163,24 @@ Add this to your Cursor settings (`settings.json`):
 
 3. **Test and use** (same as steps 2-3 above)
 
-## Available Tools (8 Core Tools)
+## Two-Tier Capability Model
 
-The MCP server provides 8 core tools corresponding to the framework's main capabilities:
+The framework splits capabilities into two tiers (see [ADR-015](../.architecture/decisions/adrs/ADR-015-mcp-skills-parity-reconciliation.md)):
+
+- **Tier 1 — Deterministic operations**: File and config operations with
+  predictable output. Available on **all channels, including this MCP server**:
+  `setup_architecture`, `create_adr`, `list_architecture_members`,
+  `get_architecture_status`, `configure_pragmatic_mode`,
+  `get_implementation_guidance`.
+- **Tier 2 — LLM-orchestrated analysis**: Multi-perspective reviews and
+  pragmatic enforcement that require an LLM to reason and generate content.
+  These are **plugin/Skills only** and are **not** exposed as MCP tools. Use the
+  `architecture-review` and `specialist-review` skills and the
+  `pragmatic-enforcer` subagent.
+
+## Available Tools (6 Tier-1 Tools)
+
+The MCP server provides 6 deterministic Tier-1 tools corresponding to the framework's core operations:
 
 ### `setup_architecture`
 **Standard Command Equivalent**: "Setup ai-software-architect"
@@ -216,39 +236,10 @@ Creates a new Architectural Decision Record with automatic numbering.
 }
 ```
 
-### `start_architecture_review`
-**Standard Command Equivalent**: "Start architecture review for [version/feature]"
-
-Creates a comprehensive multi-perspective architecture review template.
-
-**Parameters:**
-- `reviewTarget` (string, required): Version ('1.0.0') or feature name ('authentication')
-- `projectPath` (string, required): Path to your project root directory
-
-**Creates:**
-- `.architecture/reviews/[target].md` with sections for each team member
-- Review template with individual perspectives and collaborative discussion sections
-
-**Note**: This tool creates the review template. You'll need to fill in the analysis for each team member.
-
-### `specialist_review`
-**Standard Command Equivalent**: "Ask [Specialist Name] to review [target]"
-
-Creates a focused review template from a specific specialist's perspective.
-
-**Parameters:**
-- `specialist` (string, required): Specialist name or role (e.g., 'Security Specialist', 'Performance Expert')
-- `target` (string, required): What to review (e.g., 'API authentication', 'database queries')
-- `projectPath` (string, required): Path to your project root directory
-
-**Creates:**
-- `.architecture/reviews/specialist-[role]-[target].md` with specialist focus template
-
-**Behavior:**
-- If specialist exists in `members.yml`: Uses their defined perspective
-- If specialist doesn't exist: Returns error with list of available specialists
-
-**Note**: Unlike Claude Skills/Traditional methods, MCP does not auto-create missing specialists.
+> **Reviews are Tier 2, not MCP tools.** Orchestrated architecture reviews and
+> specialist reviews require LLM reasoning and are available only via the
+> plugin/Skills (`architecture-review` and `specialist-review`). See
+> [Two-Tier Capability Model](#two-tier-capability-model).
 
 ### `list_architecture_members`
 **Standard Command Equivalent**: "List architecture members"
@@ -303,12 +294,11 @@ Enables and configures Pragmatic Mode (YAGNI Enforcement) to prevent over-engine
 - **Lenient**: Raises concerns without blocking, suggests alternatives as options
 
 **When Pragmatic Mode is Enabled:**
-The Pragmatic Enforcer participates in:
-- Architecture reviews (`start_architecture_review`)
-- Specialist reviews (`specialist_review`)
-- ADR creation (`create_adr`)
-
-The Pragmatic Enforcer will:
+This tool writes the configuration. The Pragmatic Enforcer that *acts* on that
+configuration — challenging complexity, scoring necessity vs. complexity, and
+proposing simpler alternatives — is a Tier-2 capability delivered by the
+`pragmatic-enforcer` subagent and the orchestrated review skills, not an MCP
+tool. With pragmatic mode enabled, those plugin/Skills flows will:
 - Challenge complexity and abstractions with structured questions
 - Score necessity vs. complexity (target ratio <1.5)
 - Propose simpler alternatives that meet current requirements
@@ -323,66 +313,21 @@ The Pragmatic Enforcer will:
 }
 ```
 
-**Note**: This tool provides the same pragmatic mode capabilities available in Claude Skills via the `pragmatic-guard` skill.
+**Note**: This tool only manages configuration. To *run* pragmatic analysis, use
+the `pragmatic-enforcer` subagent via the plugin/Skills (see
+[Two-Tier Capability Model](#two-tier-capability-model)).
 
-### `pragmatic_enforcer`
-**Standard Command Equivalent**: "Ask Pragmatic Enforcer to review..."
+### `get_implementation_guidance`
+**Standard Command Equivalent**: "What implementation guidance applies here?"
 
-Invokes the Pragmatic Enforcer to analyze proposals, code changes, designs, or architectural decisions for over-engineering and propose simpler alternatives. This tool allows selective pragmatic analysis independent of whether Pragmatic Mode is globally enabled.
-
-**What it does:**
-1. **Load Configuration** - Reads current pragmatic mode settings (intensity, exemptions, thresholds)
-2. **Provide Framework** - Presents structured analysis framework with key questions
-3. **Guide Analysis** - Guides through necessity assessment, complexity assessment, and ratio calculation
-4. **Template Output** - Provides structured template for consistent pragmatic reviews
-5. **Context-Aware** - Adapts guidance based on review type and configured intensity
+Reads `.architecture/config.yml` and returns the configured implementation
+methodology, influences, and practices for the project.
 
 **Parameters:**
 - `projectPath` (string, required): Path to your project root directory
-- `reviewType` (string, required): Type of review - one of:
-  - `"proposal"` - Architectural recommendation or suggestion
-  - `"code"` - Code changes or implementation
-  - `"design"` - Existing design or architecture
-  - `"decision"` - Architectural decision or ADR
-  - `"implementation"` - Feature implementation plan
-- `target` (string, required): The content to review (proposal text, code snippet, design description, etc.)
-- `context` (string, optional): Additional context about current requirements, constraints, or problem being solved
-- `source` (string, optional): Source attribution (architect name, file path, PR number, etc.)
 
-**Output Provides:**
-- Key questions framework (necessity, simplicity, cost, alternatives, best practices)
-- Structured analysis template with scoring guidelines
-- Complexity-to-necessity ratio calculation guide (target < 1.5)
-- Recommendation options (Implement Now / Simplified Version / Defer / Skip)
-- Intensity-specific guidance based on configuration
-- Exemption checks for security, compliance, accessibility
-
-**Review Types Explained:**
-- **proposal**: Use for architectural recommendations from other architects or team members
-- **code**: Use for reviewing actual code changes or implementations for over-engineering
-- **design**: Use for analyzing existing architectural designs or patterns
-- **decision**: Use for reviewing architectural decisions before documenting in ADRs
-- **implementation**: Use for analyzing feature implementation plans or technical approaches
-
-**Example:**
-```javascript
-{
-  projectPath: "/path/to/project",
-  reviewType: "proposal",
-  target: "We should implement a microservices architecture with event sourcing, CQRS, and a service mesh for inter-service communication",
-  context: "Current system is a monolith with 50k LOC serving 500 users. Performance is acceptable.",
-  source: "Lead Architect"
-}
-```
-
-**Benefits:**
-- **Selective Application**: Use pragmatic analysis only when needed, without enabling globally
-- **Structured Reviews**: Consistent framework ensures thorough analysis
-- **Educational**: Helps teams learn YAGNI principles through guided analysis
-- **Flexible**: Works with any review type - proposals, code, designs, decisions, implementations
-- **Context-Aware**: Adapts to project's intensity settings and exemptions
-
-**Note**: This tool can be used even when Pragmatic Mode is disabled in config.yml. It provides the analysis framework and guidance, allowing you or your AI assistant to perform pragmatic reviews on-demand.
+**Returns:**
+- Configured methodology, influences, and practices from `config.yml`
 
 ## Usage Examples
 
@@ -403,18 +348,15 @@ Use the create_adr tool with:
 - projectPath: /Users/me/projects/myapp
 ```
 
-### Start a Review
+### Run a Review (plugin/Skills, not MCP)
+Orchestrated and specialist reviews are Tier-2 capabilities. Invoke them through
+the plugin/Skills:
 ```
-Use the start_architecture_review tool to review version 2.0.0 of our system at /Users/me/projects/myapp
+Start an architecture review for version 2.0.0
+Ask the Security Specialist to review our API authentication system
 ```
-
-### Get Specialist Input
-```
-Use the specialist_review tool with:
-- specialist: "Security Specialist"
-- target: "API authentication system"
-- projectPath: /Users/me/projects/myapp
-```
+These run via the `architecture-review` and `specialist-review` skills. See
+[Two-Tier Capability Model](#two-tier-capability-model).
 
 ### Check Status
 ```
@@ -429,14 +371,12 @@ Use the configure_pragmatic_mode tool with:
 - intensity: "balanced"
 ```
 
-### Use Pragmatic Enforcer
+### Run Pragmatic Enforcement (plugin/Skills, not MCP)
+Pragmatic analysis is a Tier-2 capability delivered by the `pragmatic-enforcer`
+subagent. Configure it with `configure_pragmatic_mode` (above), then invoke the
+analysis through the plugin/Skills:
 ```
-Use the pragmatic_enforcer tool with:
-- projectPath: /Users/me/projects/myapp
-- reviewType: "code"
-- target: "[paste code changes or proposal here]"
-- context: "This is for handling user uploads in our MVP"
-- source: "PR #123"
+Ask the Pragmatic Enforcer to review these code changes for over-engineering
 ```
 
 ### Example Workflow
@@ -452,28 +392,32 @@ Use the pragmatic_enforcer tool with:
 
 **Pre-Release Review Workflow**:
 ```
-1. Use get_architecture_status to check current state
-2. Use start_architecture_review for version 2.0.0
-3. Fill in team member perspectives in the created template
-4. Use create_adr for any new decisions identified
+1. Use get_architecture_status to check current state (MCP)
+2. Start an architecture review for version 2.0.0 (plugin/Skills — Tier 2)
+3. Use create_adr for any new decisions identified (MCP)
 ```
 
 ## Feature Parity
 
-The MCP server provides all 8 core framework tools with full feature parity to Claude Skills:
+The MCP server provides the 6 deterministic Tier-1 tools. Orchestrated reviews
+and pragmatic enforcement (Tier 2) are delivered by the plugin/Skills, not MCP
+(see [Two-Tier Capability Model](#two-tier-capability-model)).
 
-### ✅ Fully Supported Features
+### ✅ Fully Supported Features (Tier 1, via MCP)
 - **Setup Architecture**: With advanced project analysis and initial system analysis
 - **Create ADR**: With automatic numbering
-- **Architecture Review**: Template creation with all team members
-- **Specialist Review**: Focused review templates
 - **List Members**: Complete team roster
 - **Get Status**: Documentation metrics and health
-- **Pragmatic Mode**: Full config.yml reading, mode configuration, and YAGNI enforcement
+- **Configure Pragmatic Mode**: config.yml reading and mode configuration
+- **Implementation Guidance**: Configured methodology, influences, and practices
+
+### 🔀 Tier-2 Capabilities (plugin/Skills only, not MCP)
+- **Architecture Review**: Multi-perspective orchestrated review (`architecture-review` skill)
+- **Specialist Review**: Focused single-specialist review (`specialist-review` skill)
+- **Pragmatic Enforcement**: On-demand YAGNI analysis (`pragmatic-enforcer` subagent)
 
 ### ⚠️ Partially Supported Features
 - **Input Validation**: Basic filename sanitization (no security-focused validation guidance)
-- **Review Generation**: Creates templates (manual completion required vs. AI-generated)
 
 ### ❌ Not Yet Supported Features
 - **Dynamic Member Creation**: Returns error for missing specialists (vs. auto-creating them)
@@ -490,8 +434,10 @@ The MCP server provides all 8 core framework tools with full feature parity to C
 
 | Feature | MCP Server | Claude Skills | Traditional |
 |---------|-----------|---------------|-------------|
-| Core Tools (7) | ✅ All | ✅ All | ✅ All |
-| Pragmatic Mode | ✅ | ✅ | ✅ |
+| Tier-1 Deterministic Tools (6) | ✅ All | ✅ All | ✅ All |
+| Orchestrated/Specialist Reviews (Tier 2) | ❌ Plugin/Skills only | ✅ | ✅ |
+| Pragmatic Mode config | ✅ | ✅ | ✅ |
+| Pragmatic Enforcement (Tier 2) | ❌ Plugin/Skills only | ✅ | ✅ |
 | Dynamic Members | ❌ | ✅ | ✅ |
 | Recalibration | ❌ | ⚠️ Planned | ✅ |
 | Initial Analysis | ✅ Best | ❌ | ✅ |
@@ -579,10 +525,11 @@ See [main README](../README.md#integration-method-comparison) for detailed featu
 - Check file permissions in `.architecture/` directory
 - Verify write permissions for creating files
 
-**Missing specialists in specialist_review**:
-- MCP server doesn't auto-create specialists
-- Manually add to `.architecture/members.yml` or
-- Use Claude Skills/Traditional method for auto-creation
+**Need a specialist review**:
+- Specialist reviews are a Tier-2 capability — run them via the
+  `specialist-review` skill (plugin/Skills), not the MCP server
+- The MCP server does not auto-create specialists; add them to
+  `.architecture/members.yml`, or use the plugin/Skills for auto-creation
 
 ## Support
 

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+// @modelcontextprotocol/sdk is NOT imported statically here.  Static imports
+// are resolved at module-load time, which means any consumer that imports
+// ArchitectureServer (e.g. the setup-fidelity integration test running inside
+// the tools/ package) would fail with ERR_MODULE_NOT_FOUND because the SDK
+// lives in mcp/node_modules, not tools/node_modules.  The setup-only methods
+// (setupArchitecture, createADR, …) do not need the SDK at all, so we defer
+// loading it until run() via dynamic import.
 import fs from "fs-extra";
 import path from "path";
 import yaml from "yaml";
@@ -21,31 +22,33 @@ const __dirname = path.dirname(__filename);
 
 export class ArchitectureServer {
   constructor() {
-    this.server = new Server(
-      {
-        name: "ai-software-architect",
-        version: "1.6.0",
-      },
-      {
-        capabilities: {
-          tools: {},
-        },
-      }
-    );
-
-    this.setupToolHandlers();
-    this.setupErrorHandling();
-  }
-
-  setupErrorHandling() {
-    this.server.onerror = (error) => console.error("[MCP Error]", error);
+    // MCP server object is created lazily in _initServer() so that importing
+    // this class does not require @modelcontextprotocol/sdk to be resolvable.
     process.on("SIGINT", async () => {
-      await this.server.close();
+      if (this.server) await this.server.close();
       process.exit(0);
     });
   }
 
-  setupToolHandlers() {
+  // Lazily initialise the MCP Server and register all tool handlers.
+  // Safe to call multiple times (no-op after first call).
+  async _initServer() {
+    if (this.server) return;
+    const { Server } = await import("@modelcontextprotocol/sdk/server/index.js");
+    const { CallToolRequestSchema, ListToolsRequestSchema } = await import("@modelcontextprotocol/sdk/types.js");
+
+    this.server = new Server(
+      { name: "ai-software-architect", version: "1.6.0" },
+      { capabilities: { tools: {} } }
+    );
+    this.server.onerror = (error) => console.error("[MCP Error]", error);
+    this._setupToolHandlers(CallToolRequestSchema, ListToolsRequestSchema);
+  }
+
+  // Kept for API compatibility; no-op now that setup happens in _initServer.
+  setupErrorHandling() {}
+
+  _setupToolHandlers(CallToolRequestSchema, ListToolsRequestSchema) {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
       return {
         tools: [
@@ -1247,6 +1250,8 @@ ${new Date().toISOString().split('T')[0]}
   }
 
   async run() {
+    await this._initServer();
+    const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
     console.error("AI Software Architect MCP server running on stdio");

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -20,7 +20,7 @@ class ArchitectureServer {
     this.server = new Server(
       {
         name: "ai-software-architect",
-        version: "1.5.4",
+        version: "1.6.0",
       },
       {
         capabilities: {
@@ -90,46 +90,6 @@ class ArchitectureServer {
             },
           },
           {
-            name: "start_architecture_review",
-            description: "Start a comprehensive architecture review",
-            inputSchema: {
-              type: "object",
-              properties: {
-                reviewTarget: {
-                  type: "string",
-                  description: "What to review (version number like '1.0.0' or feature name)",
-                },
-                projectPath: {
-                  type: "string",
-                  description: "Path to the project root directory",
-                },
-              },
-              required: ["reviewTarget", "projectPath"],
-            },
-          },
-          {
-            name: "specialist_review",
-            description: "Get a review from a specific architecture specialist",
-            inputSchema: {
-              type: "object",
-              properties: {
-                specialist: {
-                  type: "string",
-                  description: "Name or type of specialist (e.g., 'Security Architect', 'Performance Specialist')",
-                },
-                target: {
-                  type: "string",
-                  description: "What to review (code, design, component, etc.)",
-                },
-                projectPath: {
-                  type: "string",
-                  description: "Path to the project root directory",
-                },
-              },
-              required: ["specialist", "target", "projectPath"],
-            },
-          },
-          {
             name: "list_architecture_members",
             description: "List all available architecture team members and their specialties",
             inputSchema: {
@@ -181,37 +141,6 @@ class ArchitectureServer {
             },
           },
           {
-            name: "pragmatic_enforcer",
-            description: "Invoke the Pragmatic Enforcer to analyze proposals, code changes, designs, or architectural decisions for over-engineering and propose simpler alternatives",
-            inputSchema: {
-              type: "object",
-              properties: {
-                projectPath: {
-                  type: "string",
-                  description: "Path to the project root directory",
-                },
-                reviewType: {
-                  type: "string",
-                  description: "Type of review: 'proposal' (architectural recommendation), 'code' (code changes), 'design' (existing design), 'decision' (architectural decision), or 'implementation' (feature implementation)",
-                  enum: ["proposal", "code", "design", "decision", "implementation"],
-                },
-                target: {
-                  type: "string",
-                  description: "The content to review (proposal text, code snippet, design description, decision description, or implementation plan)",
-                },
-                context: {
-                  type: "string",
-                  description: "Optional context: current requirements, constraints, why this is being proposed, what problem it solves",
-                },
-                source: {
-                  type: "string",
-                  description: "Optional: Who/what is the source (architect name, file path, PR number, etc.)",
-                },
-              },
-              required: ["projectPath", "reviewType", "target"],
-            },
-          },
-          {
             name: "get_implementation_guidance",
             description: "Get implementation methodology, influences, and practices configuration for 'Implement as the architects' command. Returns configured methodology (TDD, BDD, etc.), influences (Kent Beck, Sandi Metz, etc.), language-specific practices, testing approach, refactoring guidelines, and quality standards.",
             inputSchema: {
@@ -242,18 +171,12 @@ class ArchitectureServer {
             return await this.setupArchitecture(args);
           case "create_adr":
             return await this.createADR(args);
-          case "start_architecture_review":
-            return await this.startArchitectureReview(args);
-          case "specialist_review":
-            return await this.specialistReview(args);
           case "list_architecture_members":
             return await this.listArchitectureMembers(args);
           case "get_architecture_status":
             return await this.getArchitectureStatus(args);
           case "configure_pragmatic_mode":
             return await this.configurePragmaticMode(args);
-          case "pragmatic_enforcer":
-            return await this.pragmaticEnforcer(args);
           case "get_implementation_guidance":
             return await this.getImplementationGuidance(args);
           default:
@@ -362,7 +285,7 @@ class ArchitectureServer {
       results.push("- Review .architecture/reviews/initial-system-analysis.md");
       results.push("- Customize .architecture/members.yml for your team");
       results.push("- Create your first ADR with create_adr");
-      results.push("- Start architecture reviews with start_architecture_review");
+      results.push("- Start architecture reviews with the architecture-review skill");
       
       return {
         content: [
@@ -957,204 +880,6 @@ ${new Date().toISOString().split('T')[0]}
     };
   }
 
-  async startArchitectureReview(args) {
-    const { reviewTarget, projectPath } = args;
-    const architecturePath = path.join(projectPath, ".architecture");
-    
-    if (!(await fs.pathExists(architecturePath))) {
-      throw new Error("Architecture framework not set up. Run setup_architecture first.");
-    }
-
-    const reviewsPath = path.join(architecturePath, "reviews");
-    const membersPath = path.join(architecturePath, "members.yml");
-    
-    // Load team members
-    let members = [];
-    if (await fs.pathExists(membersPath)) {
-      const membersContent = await fs.readFile(membersPath, 'utf8');
-      const membersData = yaml.parse(membersContent);
-      members = membersData.members || [];
-    }
-
-    const reviewFilename = `${reviewTarget.replace(/\s+/g, '-').toLowerCase()}.md`;
-    
-    const reviewContent = `# Architecture Review: ${reviewTarget}
-
-## Review Overview
-
-**Target**: ${reviewTarget}
-**Date**: ${new Date().toISOString().split('T')[0]}
-**Participants**: ${members.map(m => m.name).join(', ')}
-
-## Individual Member Reviews
-
-${members.map(member => `
-### ${member.name} (${member.title})
-
-**Perspective**: ${member.perspective}
-
-**Areas of Focus**: ${member.specialties.join(', ')}
-
-**Findings**:
-- [To be filled during review]
-
-**Recommendations**:
-- [To be filled during review]
-
-**Risk Assessment**:
-- [To be filled during review]
-
----
-`).join('')}
-
-## Collaborative Discussion
-
-[Summary of team discussion and consensus findings]
-
-## Final Recommendations
-
-### High Priority
-- [Critical items requiring immediate attention]
-
-### Medium Priority  
-- [Important improvements for near-term implementation]
-
-### Low Priority
-- [Nice-to-have enhancements for future consideration]
-
-## Next Steps
-
-1. [Immediate actions]
-2. [Short-term planning]
-3. [Long-term considerations]
-
-## Sign-off
-
-- [ ] Systems Architect
-- [ ] Security Architect
-${members.filter(m => !['systems_architect', 'security_architect'].includes(m.id)).map(m => `- [ ] ${m.name}`).join('\n')}
-`;
-
-    await fs.writeFile(path.join(reviewsPath, reviewFilename), reviewContent);
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: `✅ Architecture review started!\n\nReview document: .architecture/reviews/${reviewFilename}\nParticipants: ${members.map(m => m.name).join(', ')}\n\nThe review template has been created with sections for each team member. Fill in their individual perspectives, then complete the collaborative discussion and final recommendations.`,
-        },
-      ],
-    };
-  }
-
-  async specialistReview(args) {
-    const { specialist, target, projectPath } = args;
-    const architecturePath = path.join(projectPath, ".architecture");
-    
-    if (!(await fs.pathExists(architecturePath))) {
-      throw new Error("Architecture framework not set up. Run setup_architecture first.");
-    }
-
-    const membersPath = path.join(architecturePath, "members.yml");
-    
-    // Load team members to find specialist
-    let members = [];
-    if (await fs.pathExists(membersPath)) {
-      const membersContent = await fs.readFile(membersPath, 'utf8');
-      const membersData = yaml.parse(membersContent);
-      members = membersData.members || [];
-    }
-
-    // Find matching specialist
-    const member = members.find(m => 
-      m.name.toLowerCase().includes(specialist.toLowerCase()) ||
-      m.title.toLowerCase().includes(specialist.toLowerCase()) ||
-      m.specialties.some(s => s.toLowerCase().includes(specialist.toLowerCase()))
-    );
-
-    if (!member) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `❌ Specialist "${specialist}" not found in team members.\n\nAvailable specialists:\n${members.map(m => `- ${m.name} (${m.title}): ${m.specialties.join(', ')}`).join('\n')}\n\nUse list_architecture_members to see all available team members.`,
-          },
-        ],
-      };
-    }
-
-    const reviewContent = `# Specialist Review: ${member.name}
-
-## Review Details
-
-**Specialist**: ${member.name} (${member.title})
-**Target**: ${target}
-**Date**: ${new Date().toISOString().split('T')[0]}
-**Perspective**: ${member.perspective}
-
-## Specialist Analysis
-
-### Areas of Expertise
-${member.specialties.map(s => `- ${s}`).join('\n')}
-
-### Review Focus
-${member.domains.map(d => `- ${d}`).join('\n')}
-
-### Key Findings
-
-#### Strengths
-- [Identify positive aspects from specialist perspective]
-
-#### Concerns  
-- [Highlight areas of concern or risk]
-
-#### Gaps
-- [Note missing elements or incomplete implementations]
-
-### Recommendations
-
-#### Immediate Actions
-- [Critical items requiring prompt attention]
-
-#### Improvements
-- [Enhancements to consider]
-
-#### Best Practices
-- [Industry standards and recommended approaches]
-
-### Risk Assessment
-
-**Risk Level**: [High/Medium/Low]
-
-**Key Risks**:
-- [List primary risks from specialist viewpoint]
-
-**Mitigation Strategies**:
-- [Recommended approaches to address risks]
-
-## Summary
-
-[Concise summary of specialist findings and top recommendations]
-
----
-**Specialist Sign-off**: ${member.name}
-`;
-
-    const reviewsPath = path.join(architecturePath, "reviews");
-    const filename = `specialist-${member.id}-${target.replace(/\s+/g, '-').toLowerCase()}.md`;
-    
-    await fs.writeFile(path.join(reviewsPath, filename), reviewContent);
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: `✅ Specialist review initiated!\n\n**Specialist**: ${member.name} (${member.title})\n**Focus Areas**: ${member.specialties.join(', ')}\n**Review Document**: .architecture/reviews/${filename}\n\nThe specialist review template has been created with sections tailored to ${member.name}'s expertise. Complete the analysis from their specialized perspective.`,
-        },
-      ],
-    };
-  }
-
   async listArchitectureMembers(args) {
     const { projectPath } = args;
     const membersPath = path.join(projectPath, ".architecture", "members.yml");
@@ -1196,7 +921,7 @@ ${member.domains.map(d => `- ${d}`).join('\n')}
       content: [
         {
           type: "text",
-          text: `## Architecture Team Members\n\n${membersList}\n\nUse specialist_review with any of these specialists for focused reviews.`,
+          text: `## Architecture Team Members\n\n${membersList}\n\nUse the specialist-review skill with any of these specialists for focused reviews.`,
         },
       ],
     };
@@ -1250,7 +975,7 @@ ${member.domains.map(d => `- ${d}`).join('\n')}
       content: [
         {
           type: "text",
-          text: `## Architecture Framework Status\n\n✅ **Framework Setup**: Complete\n📋 **ADRs Created**: ${status.adrs}\n🔍 **Reviews Conducted**: ${status.reviews}\n👥 **Team Members**: ${status.members}\n\n### Available Actions\n- Use \`create_adr\` to document architectural decisions\n- Use \`start_architecture_review\` for comprehensive reviews\n- Use \`specialist_review\` for focused specialist input\n- Use \`list_architecture_members\` to see team composition`,
+          text: `## Architecture Framework Status\n\n✅ **Framework Setup**: Complete\n📋 **ADRs Created**: ${status.adrs}\n🔍 **Reviews Conducted**: ${status.reviews}\n👥 **Team Members**: ${status.members}\n\n### Available Actions\n- Use \`create_adr\` to document architectural decisions\n- Use \`the architecture-review skill\` for comprehensive reviews\n- Use \`the specialist-review skill\` for focused specialist input\n- Use \`list_architecture_members\` to see team composition`,
         },
       ],
     };
@@ -1315,252 +1040,7 @@ ${member.domains.map(d => `- ${d}`).join('\n')}
       content: [
         {
           type: "text",
-          text: `## Pragmatic Mode Configuration Updated\n\n**Status**: ${statusEnabled}\n**Intensity**: ${statusIntensity}\n**Deferrals Tracking**: ${deferralsTracking}\n\n### How Pragmatic Mode Works\n\nWhen enabled, the Pragmatic Enforcer will:\n- Challenge complexity and abstractions\n- Question "best practices" that may not apply\n- Propose simpler alternatives that meet current requirements\n- Score necessity vs. complexity (target ratio <1.5)\n- ${deferralsTracking === "Enabled" ? "Track deferred decisions in .architecture/deferrals.md" : "Not track deferrals"}\n\n### Intensity Levels\n\n**Strict**: Challenges aggressively, requires strong justification\n**Balanced**: Thoughtful challenges, accepts justified complexity (recommended)\n**Lenient**: Raises concerns without blocking\n\n### Configuration\n\nFull configuration saved to: \`.architecture/config.yml\`\n\nYou can manually edit this file to customize:\n- Exemptions (security, compliance, etc.)\n- Triggers (when to challenge)\n- Thresholds (complexity scores)\n- Review phases where Pragmatic Mode applies\n\n### Next Steps\n\n${config.pragmatic_mode.enabled ? "The Pragmatic Enforcer will now participate in:\n- Architecture reviews (start_architecture_review)\n- Specialist reviews (specialist_review)\n- ADR creation (create_adr)\n\nUse these tools and the Pragmatic Enforcer will challenge over-engineering." : "Pragmatic Mode is disabled. Set enabled=true to activate YAGNI enforcement."}`,
-        },
-      ],
-    };
-  }
-
-  async pragmaticEnforcer(args) {
-    const { projectPath, reviewType, target, context, source } = args;
-    const architecturePath = path.join(projectPath, ".architecture");
-
-    if (!(await fs.pathExists(architecturePath))) {
-      throw new Error("Architecture framework not set up. Run setup_architecture first.");
-    }
-
-    // Load pragmatic mode configuration
-    const configPath = path.join(architecturePath, "config.yml");
-    let config = null;
-    let intensity = "balanced";
-
-    if (await fs.pathExists(configPath)) {
-      const configContent = await fs.readFile(configPath, 'utf8');
-      config = yaml.parse(configContent);
-      intensity = config?.pragmatic_mode?.intensity || "balanced";
-    }
-
-    // Define intensity-specific behaviors
-    const intensityBehaviors = {
-      strict: {
-        stance: "Challenges aggressively, requires strong justification for any complexity",
-        threshold: "Very high bar - must be absolutely necessary",
-        defaultRecommendation: "Defer or Simplify"
-      },
-      balanced: {
-        stance: "Challenges thoughtfully, accepts justified complexity",
-        threshold: "Reasonable bar - should have clear current value",
-        defaultRecommendation: "Evaluate trade-offs"
-      },
-      lenient: {
-        stance: "Raises concerns without blocking, suggests alternatives",
-        threshold: "Low bar - raises awareness of simpler options",
-        defaultRecommendation: "Consider alternatives"
-      }
-    };
-
-    const behavior = intensityBehaviors[intensity];
-
-    // Build the analysis report
-    const reviewTypeLabels = {
-      proposal: "Architectural Proposal",
-      code: "Code Changes",
-      design: "Existing Design",
-      decision: "Architectural Decision",
-      implementation: "Implementation Plan"
-    };
-
-    const report = [];
-    report.push("# Pragmatic Enforcer Analysis");
-    report.push("");
-    report.push(`**Review Type**: ${reviewTypeLabels[reviewType]}`);
-    report.push(`**Intensity Mode**: ${intensity} (${behavior.stance})`);
-    if (source) report.push(`**Source**: ${source}`);
-    report.push("");
-    report.push("---");
-    report.push("");
-
-    // Show what's being reviewed
-    report.push("## Target Under Review");
-    report.push("");
-    report.push("```");
-    report.push(target);
-    report.push("```");
-    report.push("");
-
-    if (context) {
-      report.push("## Context");
-      report.push("");
-      report.push(context);
-      report.push("");
-    }
-
-    report.push("---");
-    report.push("");
-    report.push("## Pragmatic Analysis Framework");
-    report.push("");
-    report.push("The Pragmatic Enforcer will now analyze this through the YAGNI lens:");
-    report.push("");
-
-    report.push("### Key Questions to Answer");
-    report.push("");
-    report.push("**Necessity Questions:**");
-    report.push("- Do we need this right now?");
-    report.push("- What breaks if we don't implement this?");
-    report.push("- What current requirement does this address?");
-    report.push("");
-
-    report.push("**Simplicity Questions:**");
-    report.push("- What's the simplest thing that could work?");
-    report.push("- Can we solve this with less code/complexity?");
-    report.push("- What are we assuming about the future?");
-    report.push("");
-
-    report.push("**Cost Questions:**");
-    report.push("- What's the cost of implementing this now?");
-    report.push("- What's the cost of waiting until we actually need it?");
-    report.push("- What's the maintenance burden?");
-    report.push("");
-
-    report.push("**Alternative Questions:**");
-    report.push("- What if we just... [propose simpler alternative]?");
-    report.push("- Could we use an existing tool/pattern?");
-    report.push("- Can we defer part of this?");
-    report.push("");
-
-    report.push("**Best Practice Questions:**");
-    report.push("- Does this best practice apply to our context?");
-    report.push("- Is this over-engineering for our scale?");
-    report.push("- Are we cargo-culting?");
-    report.push("");
-
-    report.push("---");
-    report.push("");
-    report.push("## Analysis Template");
-    report.push("");
-    report.push("Please provide your analysis using this structure:");
-    report.push("");
-
-    report.push("### 1. Necessity Assessment (Score 0-10)");
-    report.push("");
-    report.push("**Current Need**: [Score /10]");
-    report.push("- Analysis: [Why is this needed RIGHT NOW?]");
-    report.push("- Requirements addressed: [List current requirements]");
-    report.push("");
-    report.push("**Future Need**: [Score /10]");
-    report.push("- Analysis: [What future scenarios need this?]");
-    report.push("- Likelihood: [How certain are these scenarios?]");
-    report.push("");
-    report.push("**Cost of Waiting**: [Low / Medium / High]");
-    report.push("- Analysis: [What happens if we defer this?]");
-    report.push("- Reversibility: [How hard to add later?]");
-    report.push("");
-    report.push("**Overall Necessity Score**: [0-10]");
-    report.push("");
-
-    report.push("### 2. Complexity Assessment (Score 0-10)");
-    report.push("");
-    report.push("**Added Complexity**: [Score /10]");
-    report.push("- New abstractions: [List]");
-    report.push("- New dependencies: [List]");
-    report.push("- Lines of code: [Estimate]");
-    report.push("- Files affected: [Count]");
-    report.push("");
-    report.push("**Maintenance Burden**: [Score /10]");
-    report.push("- Ongoing maintenance: [Description]");
-    report.push("- Testing requirements: [Description]");
-    report.push("- Documentation needs: [Description]");
-    report.push("");
-    report.push("**Learning Curve**: [Score /10]");
-    report.push("- New concepts to learn: [List]");
-    report.push("- Team familiarity: [Assessment]");
-    report.push("");
-    report.push("**Overall Complexity Score**: [0-10]");
-    report.push("");
-
-    report.push("### 3. Complexity-to-Necessity Ratio");
-    report.push("");
-    report.push("**Ratio**: [Complexity Score / Necessity Score]");
-    report.push("");
-    report.push("**Target**: < 1.5 (complexity should not exceed necessity by more than 50%)");
-    report.push("");
-    report.push("**Assessment**: ");
-    report.push("- ✅ Acceptable (< 1.5): Complexity is justified");
-    report.push("- ⚠️  Borderline (1.5 - 2.0): Question carefully");
-    report.push("- ❌ Over-engineered (> 2.0): Strong challenge");
-    report.push("");
-
-    report.push("### 4. Simpler Alternative");
-    report.push("");
-    report.push("**Proposal**: [Describe a concrete simpler approach]");
-    report.push("");
-    report.push("**What it includes**: [List]");
-    report.push("");
-    report.push("**What it excludes**: [List]");
-    report.push("");
-    report.push("**Why it's sufficient**: [Explanation]");
-    report.push("");
-
-    report.push("### 5. Recommendation");
-    report.push("");
-    report.push("Choose one:");
-    report.push("");
-    report.push("- **✅ Implement Now**: Complexity is justified, necessity is high, proceed as proposed");
-    report.push("- **🔧 Simplified Version**: Implement the simpler alternative described above");
-    report.push("- **⏸️  Defer**: Wait until we have evidence we need this");
-    report.push("- **❌ Skip**: Not needed, doesn't add value");
-    report.push("");
-    report.push("**Recommendation**: [Your choice]");
-    report.push("");
-
-    report.push("### 6. Justification");
-    report.push("");
-    report.push("[Provide clear reasoning for your recommendation]");
-    report.push("");
-
-    report.push("---");
-    report.push("");
-    report.push("## Exemption Check");
-    report.push("");
-
-    if (config?.pragmatic_mode?.exemptions) {
-      const exemptions = config.pragmatic_mode.exemptions;
-      report.push("The following areas are exempt from simplification (but may be phased):");
-      report.push("");
-      if (exemptions.security_critical) report.push("- ✅ Security-critical features");
-      if (exemptions.data_integrity) report.push("- ✅ Data integrity requirements");
-      if (exemptions.compliance_required) report.push("- ✅ Compliance requirements");
-      if (exemptions.accessibility) report.push("- ✅ Accessibility requirements");
-      report.push("");
-      report.push("If this review involves any exempt areas, note that in your analysis.");
-      report.push("");
-    }
-
-    report.push("---");
-    report.push("");
-    report.push("## Intensity-Specific Guidance");
-    report.push("");
-    report.push(`**Current Intensity: ${intensity}**`);
-    report.push("");
-    report.push(`**Stance**: ${behavior.stance}`);
-    report.push(`**Threshold**: ${behavior.threshold}`);
-    report.push(`**Default Lean**: ${behavior.defaultRecommendation}`);
-    report.push("");
-
-    if (config?.pragmatic_mode?.enabled === false) {
-      report.push("---");
-      report.push("");
-      report.push("⚠️  **Note**: Pragmatic Mode is currently disabled in config.yml");
-      report.push("");
-      report.push("To enable automatic pragmatic enforcement in reviews, use `configure_pragmatic_mode`");
-      report.push("");
-    }
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: report.join('\n'),
+          text: `## Pragmatic Mode Configuration Updated\n\n**Status**: ${statusEnabled}\n**Intensity**: ${statusIntensity}\n**Deferrals Tracking**: ${deferralsTracking}\n\n### How Pragmatic Mode Works\n\nWhen enabled, the Pragmatic Enforcer will:\n- Challenge complexity and abstractions\n- Question "best practices" that may not apply\n- Propose simpler alternatives that meet current requirements\n- Score necessity vs. complexity (target ratio <1.5)\n- ${deferralsTracking === "Enabled" ? "Track deferred decisions in .architecture/deferrals.md" : "Not track deferrals"}\n\n### Intensity Levels\n\n**Strict**: Challenges aggressively, requires strong justification\n**Balanced**: Thoughtful challenges, accepts justified complexity (recommended)\n**Lenient**: Raises concerns without blocking\n\n### Configuration\n\nFull configuration saved to: \`.architecture/config.yml\`\n\nYou can manually edit this file to customize:\n- Exemptions (security, compliance, etc.)\n- Triggers (when to challenge)\n- Thresholds (complexity scores)\n- Review phases where Pragmatic Mode applies\n\n### Next Steps\n\n${config.pragmatic_mode.enabled ? "The Pragmatic Enforcer will now participate in:\n- Architecture reviews (the architecture-review skill)\n- Specialist reviews (the specialist-review skill)\n- ADR creation (create_adr)\n\nUse these tools and the Pragmatic Enforcer will challenge over-engineering." : "Pragmatic Mode is disabled. Set enabled=true to activate YAGNI enforcement."}`,
         },
       ],
     };

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -11,11 +11,13 @@ import path from "path";
 import yaml from "yaml";
 import { execSync } from "child_process";
 import { fileURLToPath } from "url";
+import { generateAll } from "../tools/lib/subagent-generator.js";
+import { assertContainsIds } from "../tools/lib/roster-seeding.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-class ArchitectureServer {
+export class ArchitectureServer {
   constructor() {
     this.server = new Server(
       {
@@ -222,7 +224,7 @@ class ArchitectureServer {
       results.push("\n📊 Analyzing project structure...");
       const projectAnalysis = await this.analyzeProject(projectPath);
       results.push(`- Detected languages: ${projectAnalysis.languages.join(', ')}`);
-      results.push(`- Framework: ${projectAnalysis.framework || 'None detected'}`);
+      results.push(`- Frameworks: ${projectAnalysis.frameworks.length ? projectAnalysis.frameworks.join(', ') : 'None detected'}`);
       results.push(`- Package manager: ${projectAnalysis.packageManager || 'None detected'}`);
 
       // Step 2: Clone framework if needed (simulate by copying from parent directory)
@@ -260,7 +262,20 @@ class ArchitectureServer {
       // Step 5: Customize members.yml based on project analysis
       results.push("\n👥 Customizing architecture team...");
       await this.customizeMembers(architecturePath, projectAnalysis);
-      
+
+      // Step 5b: Generate dispatchable subagents from the seeded roster (ADR-016).
+      // Seeding members.yml is not enough — the team must exist as agents/*.md.
+      const seededMembersYaml = await fs.readFile(path.join(architecturePath, "members.yml"), "utf8");
+      const subagents = generateAll(seededMembersYaml);
+      const agentsDir = path.join(projectPath, "agents");
+      await fs.ensureDir(agentsDir);
+      for (const { filename, content } of subagents) {
+        await fs.writeFile(path.join(agentsDir, filename), content);
+      }
+      const seededRoster = (yaml.parse(seededMembersYaml)?.members || []).map((m) => m.id);
+      results.push(`- Seeded ${seededRoster.length} architects: ${seededRoster.join(', ')}`);
+      results.push(`- Generated ${subagents.length} subagents in agents/`);
+
       // Step 6: Customize principles based on project
       results.push("\n📋 Customizing architectural principles...");
       await this.customizePrinciples(architecturePath, projectAnalysis);
@@ -303,6 +318,7 @@ class ArchitectureServer {
   async analyzeProject(projectPath) {
     const analysis = {
       languages: [],
+      frameworks: [],
       framework: null,
       packageManager: null,
       architecture: 'unknown',
@@ -321,11 +337,13 @@ class ArchitectureServer {
         
         // Detect frameworks
         const deps = { ...packageJson.dependencies, ...packageJson.devDependencies };
-        if (deps.react) analysis.framework = 'React';
-        else if (deps.vue) analysis.framework = 'Vue';
-        else if (deps.angular) analysis.framework = 'Angular';
-        else if (deps.express) analysis.framework = 'Express';
-        else if (deps.next) analysis.framework = 'Next.js';
+        // Multi-valued: a repo can use more than one framework, and one manifest
+        // must not mask another (ADR-016).
+        if (deps.next) analysis.frameworks.push('Next.js');
+        else if (deps.react) analysis.frameworks.push('React');
+        if (deps.vue) analysis.frameworks.push('Vue');
+        if (deps.angular) analysis.frameworks.push('Angular');
+        if (deps.express) analysis.frameworks.push('Express');
         
         if (deps.typescript || files.includes('tsconfig.json')) {
           analysis.languages.push('TypeScript');
@@ -335,20 +353,26 @@ class ArchitectureServer {
       if (files.includes('Gemfile') || files.includes('Rakefile')) {
         analysis.languages.push('Ruby');
         analysis.packageManager = 'bundler';
-        if (files.includes('config/application.rb')) analysis.framework = 'Rails';
+        // Detect Rails from Gemfile content, not just config/application.rb, so a
+        // Gemfile-only Rails app is not missed (ADR-016).
+        let gemfile = '';
+        try { gemfile = await fs.readFile(path.join(projectPath, 'Gemfile'), 'utf8'); } catch { /* ignore */ }
+        if (/gem\s+['"]rails['"]/.test(gemfile) || files.includes('config/application.rb')) {
+          analysis.frameworks.push('Rails');
+        }
       }
       
       if (files.includes('requirements.txt') || files.includes('pyproject.toml') || files.includes('setup.py')) {
         analysis.languages.push('Python');
         analysis.packageManager = 'pip';
-        if (files.includes('manage.py')) analysis.framework = 'Django';
-        else if (files.includes('app.py')) analysis.framework = 'Flask';
+        if (files.includes('manage.py')) analysis.frameworks.push('Django');
+        else if (files.includes('app.py')) analysis.frameworks.push('Flask');
       }
       
       if (files.includes('pom.xml')) {
         analysis.languages.push('Java');
         analysis.packageManager = 'maven';
-        analysis.framework = 'Spring Boot';
+        analysis.frameworks.push('Spring Boot');
       }
       
       if (files.includes('Cargo.toml')) {
@@ -371,6 +395,10 @@ class ArchitectureServer {
                       await fs.pathExists(path.join(projectPath, '.gitlab-ci.yml')) ||
                       files.includes('.travis.yml');
       
+      // Back-compat: keep a single `framework` (first detected) for any remaining
+      // caller; `frameworks` is the authoritative multi-valued list (ADR-016).
+      analysis.framework = analysis.frameworks[0] || null;
+
       if (analysis.languages.length === 0) {
         analysis.languages.push('Multiple/Unknown');
       }
@@ -392,139 +420,57 @@ class ArchitectureServer {
   }
   
   async customizeMembers(architecturePath, analysis) {
-    const members = [
-      {
-        id: "systems_architect",
-        name: "Systems Architect",
-        title: "Senior Systems Architect",
-        specialties: ["System Design", "Scalability", "Integration Patterns"],
-        disciplines: ["Software Architecture", "Systems Engineering", "Platform Design"],
-        skillsets: ["Microservices", "Event-Driven Architecture", "API Design"],
-        domains: ["Enterprise Systems", "Distributed Systems", "Cloud Architecture"],
-        perspective: "Focuses on overall system structure, scalability, and integration patterns"
-      },
-      {
-        id: "security_architect",
-        name: "Security Architect",
-        title: "Security Architecture Specialist",
-        specialties: ["Security Design", "Threat Modeling", "Compliance"],
-        disciplines: ["Security Engineering", "Risk Assessment", "Privacy Engineering"],
-        skillsets: ["Authentication", "Authorization", "Encryption", "Security Patterns"],
-        domains: ["Application Security", "Infrastructure Security", "Data Protection"],
-        perspective: "Evaluates security implications and ensures secure design patterns"
-      },
-      {
-        id: "performance_specialist",
-        name: "Performance Specialist",
-        title: "Performance Engineering Expert",
-        specialties: ["Performance Optimization", "Scalability", "Resource Management"],
-        disciplines: ["Performance Engineering", "Load Testing", "Profiling"],
-        skillsets: ["Caching", "Database Optimization", "CDN", "Monitoring"],
-        domains: ["Web Performance", "Database Performance", "Infrastructure Performance"],
-        perspective: "Focuses on system performance, bottlenecks, and optimization opportunities"
-      },
-      {
-        id: "maintainability_expert",
-        name: "Maintainability Expert",
-        title: "Code Quality and Maintainability Specialist",
-        specialties: ["Code Quality", "Technical Debt", "Refactoring"],
-        disciplines: ["Software Engineering", "Code Review", "Testing"],
-        skillsets: ["Clean Code", "Design Patterns", "Automated Testing", "Documentation"],
-        domains: ["Code Quality", "Developer Experience", "Long-term Maintenance"],
-        perspective: "Evaluates code maintainability, technical debt, and developer productivity"
-      }
-    ];
-    
-    // Add language-specific experts based on analysis
-    if (analysis.languages.includes('JavaScript') || analysis.languages.includes('TypeScript')) {
-      members.push({
-        id: "javascript_expert",
-        name: "JavaScript Expert",
-        title: "JavaScript/TypeScript Specialist",
-        specialties: ["JavaScript Patterns", "TypeScript", "Modern JS"],
-        disciplines: ["Frontend Architecture", "Node.js", "Package Management"],
-        skillsets: ["ES6+", "Async Programming", "Module Systems", "Build Tools"],
-        domains: ["Frontend Development", "Node.js Backend", "Full-stack JavaScript"],
-        perspective: "Evaluates JavaScript/TypeScript code quality, patterns, and best practices"
-      });
-    }
-    
-    if (analysis.framework) {
-      const frameworkId = analysis.framework.toLowerCase().replace(/[^a-z0-9]/g, '_');
-      members.push({
-        id: `${frameworkId}_specialist`,
-        name: `${analysis.framework} Specialist`,
-        title: `${analysis.framework} Architecture Expert`,
-        specialties: [`${analysis.framework} Patterns`, "Framework Best Practices", "Performance"],
-        disciplines: ["Framework Architecture", "Component Design", "State Management"],
-        skillsets: ["Framework APIs", "Ecosystem Tools", "Performance Optimization"],
-        domains: [`${analysis.framework} Applications`, "Framework Patterns", "Best Practices"],
-        perspective: `Evaluates ${analysis.framework} architecture, patterns, and framework-specific best practices`
-      });
-    }
-    
-    const membersData = { members };
-    await fs.writeFile(
-      path.join(architecturePath, "members.yml"),
-      yaml.stringify(membersData)
-    );
+    // ADR-016: the canonical members.yml is copied into the target during setup.
+    // Preserve it as the source of truth — do NOT overwrite it with a hardcoded
+    // list (that dropped 4 of the 8 architects and used the wrong id
+    // `security_architect`). Validate the copy against the framework source so a
+    // failed/partial copy fails loudly rather than seeding a lossy team. No stack
+    // advisors are appended initially (canonical team only).
+    const targetMembersPath = path.join(architecturePath, "members.yml");
+    const sourceMembersPath = path.resolve(__dirname, "..", ".architecture", "members.yml");
+
+    const target = yaml.parse(await fs.readFile(targetMembersPath, "utf8"));
+    const source = yaml.parse(await fs.readFile(sourceMembersPath, "utf8"));
+    const canonicalIds = (source?.members || []).map((m) => m.id);
+
+    // Fail closed if any canonical member did not make it into the target.
+    assertContainsIds(target?.members, canonicalIds);
   }
   
   async customizePrinciples(architecturePath, analysis) {
-    let principlesContent = `# Architectural Principles
+    // ADR-016: the canonical principles.md is copied into the target during
+    // setup. Preserve it — do NOT overwrite it, and do NOT write a separate
+    // .architecture/decisions/principles.md (that mislocated file was the source
+    // of broken links). Append a short technology-specific section to the
+    // canonical .architecture/principles.md.
+    const principlesPath = path.join(architecturePath, "principles.md");
+    const frameworks = analysis.frameworks && analysis.frameworks.length
+      ? analysis.frameworks
+      : (analysis.framework ? [analysis.framework] : []);
 
-## Core Principles
+    let techSection = `
 
-1. **Simplicity First** - Choose the simplest solution that meets requirements
-2. **Maintainability** - Code should be easy to understand and modify
-3. **Scalability** - Design for growth and changing requirements
-4. **Security by Design** - Security considerations integrated from the start
-5. **Performance Awareness** - Consider performance implications of decisions`;
-    
-    // Add framework-specific principles
-    if (analysis.framework) {
-      principlesContent += `
-6. **${analysis.framework} Best Practices** - Follow established ${analysis.framework} patterns and conventions`;
-    }
-    
-    if (analysis.hasTests) {
-      principlesContent += `
-7. **Test-Driven Architecture** - Design for testability and maintain comprehensive test coverage`;
-    }
-    
-    principlesContent += `
-
-## Technology-Specific Guidelines
+## Technology-Specific Guidelines (added at setup)
 
 ### Languages: ${analysis.languages.join(', ')}
 `;
-    
-    if (analysis.framework) {
-      principlesContent += `### Framework: ${analysis.framework}
-- Follow ${analysis.framework} architectural patterns
-- Leverage framework-specific optimization techniques
-- Maintain framework version compatibility
-
-`;
+    if (frameworks.length) {
+      techSection += `### Frameworks: ${frameworks.join(', ')}\n`;
+      for (const fw of frameworks) {
+        techSection += `- Follow ${fw} architectural patterns and conventions\n`;
+      }
     }
-    
-    principlesContent += `## Decision Making Process
-
-- Document significant architectural decisions as ADRs
-- Conduct regular architecture reviews
-- Involve relevant specialists in decision-making
-- Consider long-term implications
-- Align with project technology stack: ${analysis.languages.join(', ')}`;
-    
     if (analysis.packageManager) {
-      principlesContent += `
-- Follow ${analysis.packageManager} dependency management best practices`;
+      techSection += `- Follow ${analysis.packageManager} dependency-management best practices\n`;
     }
-    
-    await fs.writeFile(
-      path.join(architecturePath, "decisions", "principles.md"),
-      principlesContent
-    );
+
+    if (await fs.pathExists(principlesPath)) {
+      await fs.appendFile(principlesPath, techSection);
+    } else {
+      // Canonical principles missing (structure created without a source) — write
+      // the tech section as a minimal standalone file at the canonical path.
+      await fs.writeFile(principlesPath, `# Architectural Principles\n${techSection}`);
+    }
   }
   
   async setupTemplates(architecturePath, analysis) {
@@ -724,7 +670,7 @@ Project instructions for Claude Code.${frameworkInstructions}`);
 ## Project Overview
 
 **Languages**: ${analysis.languages.join(', ')}
-**Framework**: ${analysis.framework || 'None detected'}
+**Frameworks**: ${(analysis.frameworks && analysis.frameworks.length) ? analysis.frameworks.join(', ') : 'None detected'}
 **Package Manager**: ${analysis.packageManager || 'None detected'}
 **Has Tests**: ${analysis.hasTests ? 'Yes' : 'No'}
 **Has CI/CD**: ${analysis.hasCI ? 'Yes' : 'No'}
@@ -801,7 +747,7 @@ ${!analysis.hasCI ? '3. Set up CI/CD pipeline' : ''}
 
 ## Next Steps
 
-1. **Immediate**: Review and customize architectural principles in \`.architecture/decisions/principles.md\`
+1. **Immediate**: Review and customize architectural principles in \`.architecture/principles.md\`
 2. **Week 1**: Create ADRs for current major architectural decisions
 3. **Month 1**: Establish regular architecture review schedule
 4. **Ongoing**: Use framework for all significant architectural decisions
@@ -1299,5 +1245,9 @@ ${new Date().toISOString().split('T')[0]}
   }
 }
 
-const server = new ArchitectureServer();
-server.run().catch(console.error);
+// Run as a server only when invoked directly; allows importing the class for
+// tests/dogfood (ADR-016 fidelity test) without starting the stdio transport.
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  const server = new ArchitectureServer();
+  server.run().catch(console.error);
+}

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -11,8 +11,10 @@ import path from "path";
 import yaml from "yaml";
 import { execSync } from "child_process";
 import { fileURLToPath } from "url";
-import { generateAll } from "../tools/lib/subagent-generator.js";
-import { assertContainsIds } from "../tools/lib/roster-seeding.js";
+// Note: setup-only helpers (subagent generator, roster validation) live in
+// ../tools/lib and are imported dynamically inside setupArchitecture so the MCP
+// server still loads when run outside the full framework tree (e.g. a thin npm
+// install where Tier-1 tools work but setup, which needs the framework tree, does not).
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -265,6 +267,7 @@ export class ArchitectureServer {
 
       // Step 5b: Generate dispatchable subagents from the seeded roster (ADR-016).
       // Seeding members.yml is not enough — the team must exist as agents/*.md.
+      const { generateAll } = await import("../tools/lib/subagent-generator.js");
       const seededMembersYaml = await fs.readFile(path.join(architecturePath, "members.yml"), "utf8");
       const subagents = generateAll(seededMembersYaml);
       const agentsDir = path.join(projectPath, "agents");
@@ -279,7 +282,14 @@ export class ArchitectureServer {
       // Step 6: Customize principles based on project
       results.push("\n📋 Customizing architectural principles...");
       await this.customizePrinciples(architecturePath, projectAnalysis);
-      
+
+      // Fail closed if the canonical config.yml (with pragmatic_mode) was not
+      // carried in by the copy (ADR-016 — pragmatic mode must work out of the box).
+      const configPath = path.join(architecturePath, "config.yml");
+      if (!(await fs.pathExists(configPath)) || !/pragmatic_mode/.test(await fs.readFile(configPath, "utf8"))) {
+        throw new Error("Seeded config.yml is missing or lacks pragmatic_mode; aborting (canonical copy incomplete).");
+      }
+
       // Step 7: Set up templates
       results.push("\n📄 Setting up templates...");
       await this.setupTemplates(architecturePath, projectAnalysis);
@@ -426,15 +436,13 @@ export class ArchitectureServer {
     // `security_architect`). Validate the copy against the framework source so a
     // failed/partial copy fails loudly rather than seeding a lossy team. No stack
     // advisors are appended initially (canonical team only).
+    const { assertContainsIds, CANONICAL_MEMBER_IDS } = await import("../tools/lib/roster-seeding.js");
     const targetMembersPath = path.join(architecturePath, "members.yml");
-    const sourceMembersPath = path.resolve(__dirname, "..", ".architecture", "members.yml");
-
     const target = yaml.parse(await fs.readFile(targetMembersPath, "utf8"));
-    const source = yaml.parse(await fs.readFile(sourceMembersPath, "utf8"));
-    const canonicalIds = (source?.members || []).map((m) => m.id);
 
-    // Fail closed if any canonical member did not make it into the target.
-    assertContainsIds(target?.members, canonicalIds);
+    // Fail closed against the KNOWN canonical contract (not the source copy,
+    // which would validate vacuously if the source were itself drifted).
+    assertContainsIds(target?.members, CANONICAL_MEMBER_IDS);
   }
   
   async customizePrinciples(architecturePath, analysis) {

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -20,7 +20,7 @@ class ArchitectureServer {
     this.server = new Server(
       {
         name: "ai-software-architect",
-        version: "1.3.0",
+        version: "1.5.4",
       },
       {
         capabilities: {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,17 +1,20 @@
 {
-  "name": "ai-software-architect-mcp",
-  "version": "1.0.0",
+  "name": "ai-software-architect",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ai-software-architect-mcp",
-      "version": "1.0.0",
+      "name": "ai-software-architect",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.6.0",
         "fs-extra": "^11.2.0",
         "yaml": "^2.3.4"
+      },
+      "bin": {
+        "mcp": "index.js"
       },
       "devDependencies": {
         "@types/node": "^20.10.0"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-software-architect",
-  "version": "1.3.0",
+  "version": "1.5.4",
   "description": "MCP server for AI Software Architect framework",
   "main": "index.js",
   "type": "module",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-software-architect",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "MCP server for AI Software Architect framework",
   "main": "index.js",
   "type": "module",

--- a/skills/setup-architect/SKILL.md
+++ b/skills/setup-architect/SKILL.md
@@ -119,7 +119,7 @@ Add technology-specific members to `.architecture/members.yml`:
 
 Use template from [assets/member-template.yml](assets/member-template.yml).
 
-**Keep core members**: Systems Architect, Domain Expert, Security, Performance, Maintainability, AI Engineer, Pragmatic Enforcer.
+**Keep all canonical core members** — never drop one. The framework's `.architecture/members.yml` defines 8: Systems Architect, Domain Expert, Security Specialist, Maintainability Expert, Performance Specialist, Implementation Strategist, AI Engineer, Pragmatic Enforcer. Append technology specialists as additional advisors.
 
 **Customization details**: [references/customization-guide.md § Customize Team Members](references/customization-guide.md#customize-architecture-team-members)
 
@@ -198,7 +198,7 @@ A first-time user can verify the install by checking that **all of these are tru
 
 - [ ] `.architecture/decisions/adrs/` exists and is empty
 - [ ] `.architecture/reviews/initial-system-analysis.md` exists and is non-empty
-- [ ] `.architecture/members.yml` lists at least the seven core members plus any technology specialists added in step 4
+- [ ] `.architecture/members.yml` lists all eight canonical core members (per the framework's `.architecture/members.yml`) plus any technology specialists added in step 4
 - [ ] `.architecture/principles.md` exists and includes any framework-specific principles added in step 5
 - [ ] `.architecture/config.yml` exists (pragmatic mode flag visible)
 - [ ] `.architecture/templates/` contains `adr-template.md` and `review-template.md`

--- a/skills/setup-architect/references/customization-guide.md
+++ b/skills/setup-architect/references/customization-guide.md
@@ -227,12 +227,14 @@ Add specialists based on your detected technology stack:
 
 ### Core Members (Keep These)
 
-These core members should remain for all projects:
+These canonical core members must remain for all projects (the 8 defined in the framework's `.architecture/members.yml`):
 - **Systems Architect**: Overall architecture coherence
 - **Domain Expert**: Business domain representation
 - **Security Specialist**: Security analysis
 - **Performance Specialist**: Performance and scalability
 - **Maintainability Expert**: Code quality and technical debt
+- **Implementation Strategist**: Change sequencing, blast radius, reversibility
+- **AI Engineer**: AI/ML integration and observability
 - **Pragmatic Enforcer**: YAGNI enforcement (if pragmatic mode enabled)
 
 **Add technology specialists, don't replace core members.**

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -14,6 +14,7 @@ import { countInstructions } from './lib/instruction-counter.js';
 import { validateAdr } from './lib/adr-validator.js';
 import { generateAll } from './lib/subagent-generator.js';
 import { discoverSource, PLUGIN_NAME } from './lib/setup-source-discovery.js';
+import { checkConsistency, FRAMEWORK_VERSION_SOURCES } from './lib/version-consistency.js';
 
 const [,, command, ...args] = process.argv;
 
@@ -23,6 +24,7 @@ const COMMANDS = {
   'generate-subagents': generateSubagentsCommand,
   'find-source': findSourceCommand,
   count: countCommand,
+  'version-check': versionCheckCommand,
   help: helpCommand
 };
 
@@ -284,6 +286,34 @@ function countCommand(args) {
 }
 
 /**
+ * Verify the framework version is consistent across all distribution channels.
+ * Enforces the single-version commitment from ADR-011. Exits 1 on drift.
+ */
+function versionCheckCommand() {
+  console.log(`\n🔖 Checking framework version consistency...\n`);
+
+  const entries = FRAMEWORK_VERSION_SOURCES.map(src => ({
+    label: src.label,
+    version: src.read(readFileSync(resolve('..', src.file), 'utf8')),
+  }));
+
+  const result = checkConsistency(entries);
+
+  for (const entry of entries) {
+    const mark = entry.version === null ? '❓' : entry.version === result.canonical ? '=' : '✗';
+    console.log(`  ${mark} ${entry.label}: ${entry.version ?? 'not found'}`);
+  }
+
+  if (result.consistent) {
+    console.log(`\n✨ All channels report ${result.canonical}.\n`);
+    return;
+  }
+
+  console.log(`\n❌ Version drift from canonical ${result.canonical} (ADR-011 requires one version).\n`);
+  process.exit(1);
+}
+
+/**
  * Show help
  */
 function helpCommand() {
@@ -296,6 +326,7 @@ Usage:
   node cli.js generate-subagents [--check] Generate agents/*.md from members.yml
   node cli.js find-source [--json]         Discover the framework source for setup-architect
   npm run count [files...]                 Count instructions (default: ../AGENTS.md ../CLAUDE.md)
+  node cli.js version-check                Verify one framework version across all channels (ADR-011)
 
 Examples:
   npm run validate

--- a/tools/lib/roster-seeding.js
+++ b/tools/lib/roster-seeding.js
@@ -1,0 +1,52 @@
+/**
+ * Roster seeding for setup (ADR-016).
+ *
+ * Setup copies the framework's canonical `members.yml` into the target project.
+ * These helpers preserve that canonical roster (never substitute a core member)
+ * and append stack-specific advisors only when their id is unique. A separate
+ * validation guards against a failed/partial copy (fail closed).
+ *
+ * Pure functions; file IO stays in the caller, mirroring the other lib modules.
+ */
+
+/**
+ * Merge advisors onto the canonical roster.
+ * Canonical members are preserved in order; an advisor is appended only if its
+ * id does not collide with an existing member (canonical members never substituted).
+ *
+ * @param {Array<{id: string}>} canonicalMembers - the copied canonical roster
+ * @param {Array<{id: string}>} [advisors] - stack-specific advisors to append
+ * @returns {Array} merged member list
+ */
+export function seedRoster(canonicalMembers, advisors = []) {
+  if (!Array.isArray(canonicalMembers) || canonicalMembers.length === 0) {
+    throw new Error('seedRoster: canonical roster is missing or empty');
+  }
+  const ids = new Set(canonicalMembers.map(m => m && m.id));
+  const merged = [...canonicalMembers];
+  for (const advisor of advisors || []) {
+    if (advisor && typeof advisor.id === 'string' && advisor.id && !ids.has(advisor.id)) {
+      merged.push(advisor);
+      ids.add(advisor.id);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Fail closed if any required (canonical) id is absent from the roster.
+ * Used to detect a failed/partial framework copy before setup proceeds.
+ *
+ * @param {Array<{id: string}>} members
+ * @param {string[]} requiredIds
+ * @returns {true} when all present
+ * @throws when any required id is missing
+ */
+export function assertContainsIds(members, requiredIds) {
+  const present = new Set((Array.isArray(members) ? members : []).map(m => m && m.id));
+  const missing = (requiredIds || []).filter(id => !present.has(id));
+  if (missing.length > 0) {
+    throw new Error(`Roster is missing canonical members: ${missing.join(', ')}`);
+  }
+  return true;
+}

--- a/tools/lib/roster-seeding.js
+++ b/tools/lib/roster-seeding.js
@@ -1,48 +1,40 @@
 /**
- * Roster seeding for setup (ADR-016).
+ * Roster validation for setup (ADR-016).
  *
  * Setup copies the framework's canonical `members.yml` into the target project.
- * These helpers preserve that canonical roster (never substitute a core member)
- * and append stack-specific advisors only when their id is unique. A separate
- * validation guards against a failed/partial copy (fail closed).
+ * This guards against a failed/partial/drifted copy by asserting the seeded
+ * roster contains the known canonical core team — a fixed contract, NOT derived
+ * from the copy itself (deriving it from the copy would pass vacuously when the
+ * source is itself drifted).
  *
- * Pure functions; file IO stays in the caller, mirroring the other lib modules.
+ * The canonical id list is contract data; the `roster-seeding` unit test pins it
+ * against the real `.architecture/members.yml`, so the two cannot silently drift.
+ *
+ * Pure functions; file IO stays in the caller.
  */
 
-/**
- * Merge advisors onto the canonical roster.
- * Canonical members are preserved in order; an advisor is appended only if its
- * id does not collide with an existing member (canonical members never substituted).
- *
- * @param {Array<{id: string}>} canonicalMembers - the copied canonical roster
- * @param {Array<{id: string}>} [advisors] - stack-specific advisors to append
- * @returns {Array} merged member list
- */
-export function seedRoster(canonicalMembers, advisors = []) {
-  if (!Array.isArray(canonicalMembers) || canonicalMembers.length === 0) {
-    throw new Error('seedRoster: canonical roster is missing or empty');
-  }
-  const ids = new Set(canonicalMembers.map(m => m && m.id));
-  const merged = [...canonicalMembers];
-  for (const advisor of advisors || []) {
-    if (advisor && typeof advisor.id === 'string' && advisor.id && !ids.has(advisor.id)) {
-      merged.push(advisor);
-      ids.add(advisor.id);
-    }
-  }
-  return merged;
-}
+/** The canonical core architecture team (ADR-016). Setup must seed all of these. */
+export const CANONICAL_MEMBER_IDS = [
+  'systems_architect',
+  'domain_expert',
+  'security_specialist',
+  'maintainability_expert',
+  'performance_specialist',
+  'implementation_strategist',
+  'ai_engineer',
+  'pragmatic_enforcer',
+];
 
 /**
  * Fail closed if any required (canonical) id is absent from the roster.
- * Used to detect a failed/partial framework copy before setup proceeds.
+ * Detects a failed/partial/drifted framework copy before setup proceeds.
  *
  * @param {Array<{id: string}>} members
- * @param {string[]} requiredIds
+ * @param {string[]} [requiredIds] - defaults to the canonical contract
  * @returns {true} when all present
  * @throws when any required id is missing
  */
-export function assertContainsIds(members, requiredIds) {
+export function assertContainsIds(members, requiredIds = CANONICAL_MEMBER_IDS) {
   const present = new Set((Array.isArray(members) ? members : []).map(m => m && m.id));
   const missing = (requiredIds || []).filter(id => !present.has(id));
   if (missing.length > 0) {

--- a/tools/lib/version-consistency.js
+++ b/tools/lib/version-consistency.js
@@ -1,0 +1,85 @@
+/**
+ * Version Consistency - Guards the single-version commitment from ADR-011
+ *
+ * ADR-011 ("Architectural Decision (Regardless of Path)") commits to a single
+ * framework version shared across all distribution channels, enforced by an
+ * automated pipeline. This module is the proportional, deterministic guard that
+ * makes the commitment checkable (the per-file checks the pipeline was meant to
+ * cover). See ADR-009 for the script-based-deterministic-operations rationale.
+ *
+ * Pure functions only; file IO lives in cli.js, mirroring the other lib modules.
+ *
+ * Deliberately NOT covered (legitimately independent versions):
+ *   - tools/package.json        → internal package "architecture-tools", not a channel
+ *   - config.yml architecture_version → the target project's architecture version
+ *   - AGENTS.md Documentation Version  → doc-structure version (ADR-006)
+ */
+
+const SEMVER = '([0-9]+\\.[0-9]+\\.[0-9]+)';
+
+/**
+ * Extract a quoted version value following a key, e.g.
+ *   "version": "1.5.4"   (JSON)
+ *   version: "1.5.4"     (JS object / YAML)
+ * The \b word boundary prevents `version` from matching inside `framework_version`.
+ *
+ * @param {string} content - File content
+ * @param {string} [key='version'] - The key whose value to read
+ * @returns {string|null} The semver string, or null if not found
+ */
+export function extractVersion(content, key = 'version') {
+  const re = new RegExp(`["']?\\b${key}\\b["']?\\s*[:=]\\s*["']${SEMVER}["']`);
+  const m = content.match(re);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extract a markdown bold-labeled version, e.g.
+ *   **Framework Version**: 1.5.4
+ *
+ * @param {string} content - File content
+ * @param {string} label - The bold label text (without asterisks)
+ * @returns {string|null} The semver string, or null if not found
+ */
+export function extractLabeledVersion(content, label) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`\\*\\*${escaped}\\*\\*:\\s*${SEMVER}`);
+  const m = content.match(re);
+  return m ? m[1] : null;
+}
+
+/**
+ * Check that every entry's version matches the canonical version.
+ *
+ * @param {Array<{label: string, version: string|null}>} entries
+ * @param {string} [canonical] - Reference version; defaults to the first non-null entry
+ * @returns {{canonical: string|null, consistent: boolean, mismatches: Array, missing: Array}}
+ */
+export function checkConsistency(entries, canonical) {
+  const ref = canonical ?? entries.find(e => e.version)?.version ?? null;
+  const missing = entries.filter(e => e.version === null);
+  const mismatches = entries.filter(e => e.version !== null && e.version !== ref);
+  return {
+    canonical: ref,
+    consistent: mismatches.length === 0 && missing.length === 0,
+    mismatches,
+    missing,
+  };
+}
+
+/**
+ * Files that MUST share the framework version, with how to read each one.
+ * Paths are repo-root-relative. The first entry (plugin.json) is canonical.
+ * `read` takes file content and returns a semver string or null.
+ * This is data, not IO — callers (cli.js, tests) do the reading.
+ */
+export const FRAMEWORK_VERSION_SOURCES = [
+  { label: '.claude-plugin/plugin.json', file: '.claude-plugin/plugin.json', read: c => extractVersion(c) },
+  { label: '.claude-plugin/marketplace.json', file: '.claude-plugin/marketplace.json', read: c => extractVersion(c) },
+  { label: 'mcp/package.json', file: 'mcp/package.json', read: c => extractVersion(c) },
+  { label: 'mcp/index.js', file: 'mcp/index.js', read: c => extractVersion(c) },
+  { label: '.architecture/config.yml (framework_version)', file: '.architecture/config.yml', read: c => extractVersion(c, 'framework_version') },
+  { label: 'CLAUDE.md (Framework Version)', file: 'CLAUDE.md', read: c => extractLabeledVersion(c, 'Framework Version') },
+  { label: 'AGENTS.md (Framework Version)', file: 'AGENTS.md', read: c => extractLabeledVersion(c, 'Framework Version') },
+  { label: 'AGENTS.md (MCP Server Version)', file: 'AGENTS.md', read: c => extractLabeledVersion(c, 'MCP Server Version') },
+];

--- a/tools/package.json
+++ b/tools/package.json
@@ -10,7 +10,8 @@
     "validate-adr": "node cli.js validate-adr",
     "generate-subagents": "node cli.js generate-subagents",
     "find-source": "node cli.js find-source",
-    "count": "node cli.js count"
+    "count": "node cli.js count",
+    "version-check": "node cli.js version-check"
   },
   "keywords": ["documentation", "validation", "architecture"],
   "author": "AI Software Architect",

--- a/tools/test/roster-seeding.test.js
+++ b/tools/test/roster-seeding.test.js
@@ -4,65 +4,45 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
-import { seedRoster, assertContainsIds } from '../lib/roster-seeding.js';
+import { assertContainsIds, CANONICAL_MEMBER_IDS } from '../lib/roster-seeding.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.join(__dirname, '..', '..');
 
-const CANONICAL_IDS = [
-  'systems_architect', 'domain_expert', 'security_specialist', 'maintainability_expert',
-  'performance_specialist', 'implementation_strategist', 'ai_engineer', 'pragmatic_enforcer',
-];
-
-describe('Roster seeding (ADR-016)', () => {
-  describe('seedRoster', () => {
-    it('preserves the canonical roster when no advisors are given', () => {
-      const canonical = [{ id: 'a' }, { id: 'b' }];
-      assert.deepStrictEqual(seedRoster(canonical).map(m => m.id), ['a', 'b']);
-    });
-
-    it('appends an advisor with a unique id', () => {
-      const merged = seedRoster([{ id: 'a' }], [{ id: 'rails_advisor' }]);
-      assert.deepStrictEqual(merged.map(m => m.id), ['a', 'rails_advisor']);
-    });
-
-    it('never substitutes a canonical member on id collision', () => {
-      const canonical = [{ id: 'security_specialist', canonical: true }];
-      const merged = seedRoster(canonical, [{ id: 'security_specialist', canonical: false }]);
-      assert.strictEqual(merged.length, 1);
-      assert.strictEqual(merged[0].canonical, true);
-    });
-
-    it('throws on an empty/missing canonical roster (fail closed)', () => {
-      assert.throws(() => seedRoster([]), /missing or empty/);
-      assert.throws(() => seedRoster(null), /missing or empty/);
-    });
-  });
-
+describe('Roster validation (ADR-016)', () => {
   describe('assertContainsIds', () => {
     it('passes when all required ids are present', () => {
       assert.strictEqual(assertContainsIds([{ id: 'a' }, { id: 'b' }], ['a']), true);
     });
 
-    it('throws listing the missing ids', () => {
+    it('throws listing the missing ids (fail closed)', () => {
       assert.throws(
         () => assertContainsIds([{ id: 'a' }], ['a', 'pragmatic_enforcer']),
         /pragmatic_enforcer/
       );
     });
+
+    it('defaults to the canonical contract', () => {
+      assert.throws(() => assertContainsIds([{ id: 'systems_architect' }]), /domain_expert/);
+    });
   });
 
-  // Fidelity guard: the framework's own canonical members.yml must carry all 8
-  // core architects. This is the source setup copies; if it drifts, every new
-  // install drifts. (ADR-016)
+  // Fidelity guard: the framework's own canonical members.yml must carry exactly
+  // the canonical contract. This is the source setup copies; if it drifts, every
+  // new install drifts — and the fail-closed validation's contract drifts with it.
   describe('canonical members.yml (source of truth)', () => {
-    it('defines all 8 canonical architects with correct ids', () => {
+    it('contains every canonical id and the correct security id', () => {
       const doc = parseYaml(readFileSync(path.join(repoRoot, '.architecture/members.yml'), 'utf8'));
-      assert.doesNotThrow(() => assertContainsIds(doc.members, CANONICAL_IDS));
-      // and uses security_specialist, not the drifted security_architect
+      assert.doesNotThrow(() => assertContainsIds(doc.members, CANONICAL_MEMBER_IDS));
       const ids = doc.members.map(m => m.id);
       assert.ok(ids.includes('security_specialist'));
       assert.ok(!ids.includes('security_architect'));
+    });
+
+    it('contract and source agree (no drift between code and members.yml)', () => {
+      const doc = parseYaml(readFileSync(path.join(repoRoot, '.architecture/members.yml'), 'utf8'));
+      const coreIds = doc.members.map(m => m.id).filter(id => CANONICAL_MEMBER_IDS.includes(id));
+      assert.deepStrictEqual([...coreIds].sort(), [...CANONICAL_MEMBER_IDS].sort());
     });
   });
 });

--- a/tools/test/roster-seeding.test.js
+++ b/tools/test/roster-seeding.test.js
@@ -1,0 +1,68 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { seedRoster, assertContainsIds } from '../lib/roster-seeding.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, '..', '..');
+
+const CANONICAL_IDS = [
+  'systems_architect', 'domain_expert', 'security_specialist', 'maintainability_expert',
+  'performance_specialist', 'implementation_strategist', 'ai_engineer', 'pragmatic_enforcer',
+];
+
+describe('Roster seeding (ADR-016)', () => {
+  describe('seedRoster', () => {
+    it('preserves the canonical roster when no advisors are given', () => {
+      const canonical = [{ id: 'a' }, { id: 'b' }];
+      assert.deepStrictEqual(seedRoster(canonical).map(m => m.id), ['a', 'b']);
+    });
+
+    it('appends an advisor with a unique id', () => {
+      const merged = seedRoster([{ id: 'a' }], [{ id: 'rails_advisor' }]);
+      assert.deepStrictEqual(merged.map(m => m.id), ['a', 'rails_advisor']);
+    });
+
+    it('never substitutes a canonical member on id collision', () => {
+      const canonical = [{ id: 'security_specialist', canonical: true }];
+      const merged = seedRoster(canonical, [{ id: 'security_specialist', canonical: false }]);
+      assert.strictEqual(merged.length, 1);
+      assert.strictEqual(merged[0].canonical, true);
+    });
+
+    it('throws on an empty/missing canonical roster (fail closed)', () => {
+      assert.throws(() => seedRoster([]), /missing or empty/);
+      assert.throws(() => seedRoster(null), /missing or empty/);
+    });
+  });
+
+  describe('assertContainsIds', () => {
+    it('passes when all required ids are present', () => {
+      assert.strictEqual(assertContainsIds([{ id: 'a' }, { id: 'b' }], ['a']), true);
+    });
+
+    it('throws listing the missing ids', () => {
+      assert.throws(
+        () => assertContainsIds([{ id: 'a' }], ['a', 'pragmatic_enforcer']),
+        /pragmatic_enforcer/
+      );
+    });
+  });
+
+  // Fidelity guard: the framework's own canonical members.yml must carry all 8
+  // core architects. This is the source setup copies; if it drifts, every new
+  // install drifts. (ADR-016)
+  describe('canonical members.yml (source of truth)', () => {
+    it('defines all 8 canonical architects with correct ids', () => {
+      const doc = parseYaml(readFileSync(path.join(repoRoot, '.architecture/members.yml'), 'utf8'));
+      assert.doesNotThrow(() => assertContainsIds(doc.members, CANONICAL_IDS));
+      // and uses security_specialist, not the drifted security_architect
+      const ids = doc.members.map(m => m.id);
+      assert.ok(ids.includes('security_specialist'));
+      assert.ok(!ids.includes('security_architect'));
+    });
+  });
+});

--- a/tools/test/setup-fidelity.test.js
+++ b/tools/test/setup-fidelity.test.js
@@ -30,11 +30,12 @@ describe('Setup fidelity (ADR-016) — setup_architecture end-to-end', () => {
 
   after(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
 
-  it('seeds the full canonical team with correct ids (no drift)', async () => {
+  it('seeds exactly the canonical team (no drift, no extras)', async () => {
     const doc = parseYaml(await readFile(path.join(dir, '.architecture/members.yml'), 'utf8'));
-    const ids = doc.members.map(m => m.id);
-    for (const id of CANONICAL_IDS) assert.ok(ids.includes(id), `roster missing ${id}`);
-    assert.ok(ids.includes('security_specialist'), 'expected canonical security_specialist');
+    const ids = doc.members.map(m => m.id).sort();
+    // No advisors are appended initially, so the roster must equal the canonical
+    // 8 EXACTLY — this catches both omissions and a wrong-id member sneaking in.
+    assert.deepStrictEqual(ids, [...CANONICAL_IDS].sort());
     assert.ok(!ids.includes('security_architect'), 'drifted security_architect must be gone');
   });
 

--- a/tools/test/setup-fidelity.test.js
+++ b/tools/test/setup-fidelity.test.js
@@ -1,0 +1,63 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp, rm, writeFile, readFile, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { ArchitectureServer } from '../../mcp/index.js';
+
+const CANONICAL_IDS = [
+  'systems_architect', 'domain_expert', 'security_specialist', 'maintainability_expert',
+  'performance_specialist', 'implementation_strategist', 'ai_engineer', 'pragmatic_enforcer',
+];
+
+// Integration test for ADR-016: run the real MCP setup against a polyglot fixture
+// and assert the install is faithful and usable (canonical team + dispatchable
+// subagents + pragmatic config + correct principles location + unmasked stack).
+describe('Setup fidelity (ADR-016) — setup_architecture end-to-end', () => {
+  let dir;
+
+  before(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), 'asa-setup-'));
+    // Polyglot fixture: Rails (Gemfile) + Express (package.json) — the dogfood case.
+    await writeFile(path.join(dir, 'package.json'),
+      JSON.stringify({ name: 'demo', dependencies: { express: '^4.18.0' } }));
+    await writeFile(path.join(dir, 'Gemfile'),
+      "source 'https://rubygems.org'\ngem 'rails', '~> 7.1'\ngem 'sqlite3'\n");
+    await new ArchitectureServer().setupArchitecture({ projectPath: dir });
+  });
+
+  after(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+  it('seeds the full canonical team with correct ids (no drift)', async () => {
+    const doc = parseYaml(await readFile(path.join(dir, '.architecture/members.yml'), 'utf8'));
+    const ids = doc.members.map(m => m.id);
+    for (const id of CANONICAL_IDS) assert.ok(ids.includes(id), `roster missing ${id}`);
+    assert.ok(ids.includes('security_specialist'), 'expected canonical security_specialist');
+    assert.ok(!ids.includes('security_architect'), 'drifted security_architect must be gone');
+  });
+
+  it('generates dispatchable subagents, including pragmatic-enforcer', async () => {
+    const agents = await readdir(path.join(dir, 'agents'));
+    assert.ok(agents.includes('pragmatic-enforcer.md'), 'pragmatic-enforcer subagent must exist');
+    assert.ok(agents.length >= CANONICAL_IDS.length, `expected >=8 subagents, got ${agents.length}`);
+  });
+
+  it('writes principles to the canonical path, not the mislocated decisions/ path', () => {
+    assert.ok(existsSync(path.join(dir, '.architecture/principles.md')), 'canonical principles.md missing');
+    assert.ok(!existsSync(path.join(dir, '.architecture/decisions/principles.md')),
+      'mislocated decisions/principles.md must not be created');
+  });
+
+  it('seeds a config.yml carrying pragmatic_mode', async () => {
+    const cfg = await readFile(path.join(dir, '.architecture/config.yml'), 'utf8');
+    assert.match(cfg, /pragmatic_mode/);
+  });
+
+  it('detects all frameworks (Rails not masked by Express)', async () => {
+    const analysis = await readFile(path.join(dir, '.architecture/reviews/initial-system-analysis.md'), 'utf8');
+    assert.match(analysis, /Rails/, 'Rails should be detected');
+    assert.match(analysis, /Express/, 'Express should be detected');
+  });
+});

--- a/tools/test/version-consistency.test.js
+++ b/tools/test/version-consistency.test.js
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  extractVersion,
+  extractLabeledVersion,
+  checkConsistency,
+  FRAMEWORK_VERSION_SOURCES,
+} from '../lib/version-consistency.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, '..', '..');
+
+describe('Version Consistency', () => {
+  describe('extractVersion', () => {
+    it('reads a JSON version field', () => {
+      assert.strictEqual(extractVersion('{\n  "version": "1.5.4"\n}'), '1.5.4');
+    });
+
+    it('reads an unquoted-key version (JS object)', () => {
+      assert.strictEqual(extractVersion('        version: "1.5.4",'), '1.5.4');
+    });
+
+    it('does not match `version` inside `framework_version`', () => {
+      // Plain-key lookup must skip the compound key entirely.
+      assert.strictEqual(extractVersion('framework_version: "1.2.0"'), null);
+    });
+
+    it('reads a named key when asked', () => {
+      assert.strictEqual(
+        extractVersion('  framework_version: "1.5.4"', 'framework_version'),
+        '1.5.4'
+      );
+    });
+
+    it('returns null when no version present', () => {
+      assert.strictEqual(extractVersion('no version here'), null);
+    });
+  });
+
+  describe('extractLabeledVersion', () => {
+    it('reads a bold-labeled markdown version', () => {
+      assert.strictEqual(
+        extractLabeledVersion('**Framework Version**: 1.5.4', 'Framework Version'),
+        '1.5.4'
+      );
+    });
+
+    it('distinguishes labels in the same document', () => {
+      const doc = '**Framework Version**: 1.5.4\n**MCP Server Version**: 1.3.0';
+      assert.strictEqual(extractLabeledVersion(doc, 'MCP Server Version'), '1.3.0');
+    });
+
+    it('returns null when label absent', () => {
+      assert.strictEqual(extractLabeledVersion('nothing', 'Framework Version'), null);
+    });
+  });
+
+  describe('checkConsistency', () => {
+    it('is consistent when all versions match', () => {
+      const result = checkConsistency([
+        { label: 'a', version: '1.5.4' },
+        { label: 'b', version: '1.5.4' },
+      ]);
+      assert.strictEqual(result.consistent, true);
+      assert.strictEqual(result.canonical, '1.5.4');
+    });
+
+    it('flags mismatches against the canonical (first) version', () => {
+      const result = checkConsistency([
+        { label: 'a', version: '1.5.4' },
+        { label: 'b', version: '1.2.0' },
+      ]);
+      assert.strictEqual(result.consistent, false);
+      assert.strictEqual(result.mismatches.length, 1);
+      assert.strictEqual(result.mismatches[0].label, 'b');
+    });
+
+    it('flags missing (unreadable) versions', () => {
+      const result = checkConsistency([
+        { label: 'a', version: '1.5.4' },
+        { label: 'b', version: null },
+      ]);
+      assert.strictEqual(result.consistent, false);
+      assert.strictEqual(result.missing.length, 1);
+    });
+
+    it('honors an explicit canonical version', () => {
+      const result = checkConsistency([{ label: 'a', version: '1.5.4' }], '2.0.0');
+      assert.strictEqual(result.consistent, false);
+    });
+  });
+
+  // Recurrence guard: the real repo files must agree. This is the check the
+  // ADR-011 release pipeline was meant to enforce. Fails CI on drift.
+  describe('repository (ADR-011 single-version commitment)', () => {
+    it('every framework version source agrees', () => {
+      const entries = FRAMEWORK_VERSION_SOURCES.map(src => ({
+        label: src.label,
+        version: src.read(readFileSync(path.join(repoRoot, src.file), 'utf8')),
+      }));
+
+      const result = checkConsistency(entries);
+
+      const detail = [
+        ...result.mismatches.map(m => `  ${m.label}: ${m.version} (expected ${result.canonical})`),
+        ...result.missing.map(m => `  ${m.label}: version not found`),
+      ].join('\n');
+
+      assert.ok(
+        result.consistent,
+        `Framework version drift (canonical ${result.canonical}):\n${detail}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Output of a structural first-principles examination of the AI Software Architect framework, plus the fixes it surfaced. Two ADRs were reviewed by the full 8-architect panel (dogfooding the framework on itself) and accepted.

## Commits
1. **fix: unify framework version across all channels + add drift guard** — the framework version had drifted four ways (plugin/marketplace 1.5.4, MCP 1.3.0, config/docs 1.2.0) despite ADR-011 promising a single version. Unified all sources; added `version-check` + a CI-enforced consistency test.
2. **feat(mcp)!: two-tier capability model — remove Tier-2 MCP review tools (ADR-015)** — BREAKING. Removed `start_architecture_review`, `specialist_review`, `pragmatic_enforcer` (~520 lines): an MCP server has no agent loop and these only emitted blank templates under names shadowing the real Skills. Reviews/pragmatic enforcement are now plugin/Skills-only. Bumped to 1.6.0.
3. **docs(adr): revise ADR-016 per 8-architect review + add review doc** — the review caught four factual errors in the draft.
4. **feat(setup): derive team & stack from canonical sources (ADR-016)** — setup now preserves the canonical members.yml (all 8 architects, correct ids) instead of overwriting with a hardcoded 4-member list, generates dispatchable subagents, writes principles to the canonical path, and detects all frameworks (Rails no longer masked by Express).
5. **fix(setup): address ADR-016 verification-panel findings** — post-implementation review caught a bug the tests could not: a static cross-package import would break the published MCP server (made dynamic); plus fail-closed roster validation and an exact-equality fidelity test.

## ADRs
- ADR-015 (Accepted): MCP/Skills two-tier capability model
- ADR-016 (Accepted): setup fidelity from canonical sources
- Review artifacts under `.architecture/reviews/` (structural examination + per-ADR architect reviews)

## Verification
- Tests: 99/99 pass (incl. an end-to-end setup-fidelity integration test)
- `validate` (links), `validate-adr` (17 ADRs), `version-check` (1.6.0) — all green

## Deferred (documented in ADR-016, non-blocking)
Source-discovery rewiring, re-run/merge for existing installs, shared MCP↔Skill module, datastore surfacing, manifest-input sanitization.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfjuiRirkFpcaUJFdEPEdW)_