### PR TITLE
fix(mcp): stale principles path in CLAUDE.md integration, ADR filename slugging, copy-filter node_modules leak

### DIFF
--- a/mcp/index.js
+++ b/mcp/index.js
@@ -10,7 +10,6 @@
 import fs from "fs-extra";
 import path from "path";
 import yaml from "yaml";
-import { execSync } from "child_process";
 import { fileURLToPath } from "url";
 // Note: setup-only helpers (subagent generator, roster validation) live in
 // ../tools/lib and are imported dynamically inside setupArchitecture so the MCP
@@ -242,8 +241,10 @@ export class ArchitectureServer {
       await fs.copy(frameworkSourcePath, tempClonePath, {
         filter: (src) => {
           const relativePath = path.relative(frameworkSourcePath, src);
-          // Skip git, node_modules, and other non-template files
-          return !relativePath.match(/^(.git|\.git|node_modules|mcp\/node_modules)/)
+          // Skip git and any node_modules (root, mcp/, tools/, …) — a nested
+          // node_modules must never be copied into the target project.
+          return !relativePath.match(/^\.git(\/|$)/)
+            && !relativePath.split(path.sep).includes("node_modules")
             && !relativePath.includes('README.md')
             && !relativePath.includes('USAGE')
             && !relativePath.includes('INSTALL.md');
@@ -652,12 +653,13 @@ This project uses the AI Software Architect framework for structured architectur
 - **Recalibration**: "Start architecture recalibration for 'feature name'"
 
 ### Framework Structure
-- \`.architecture/decisions/\` - Architectural Decision Records and principles
+- \`.architecture/decisions/\` - Architectural Decision Records
+- \`.architecture/principles.md\` - Architectural principles
 - \`.architecture/reviews/\` - Architecture review documents
 - \`.architecture/recalibration/\` - Implementation plans from reviews
 - \`.architecture/members.yml\` - Architecture team member definitions
 
-Refer to \`.architecture/decisions/principles.md\` for architectural guidance.
+Refer to \`.architecture/principles.md\` for architectural guidance.
 `;
     
     if (await fs.pathExists(claudeMdPath)) {
@@ -800,7 +802,13 @@ The AI Software Architect framework has been configured with:
       .sort((a, b) => a - b);
     
     const nextNumber = adrNumbers.length > 0 ? Math.max(...adrNumbers) + 1 : 1;
-    const adrFilename = `${nextNumber.toString().padStart(4, '0')}-${title.toLowerCase().replace(/\s+/g, '-')}.md`;
+    // Slugify the title for the filename: path separators, colons, etc. must not
+    // survive (a "/" would make writeFile target a nonexistent subdirectory).
+    const titleSlug = title.toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      || 'untitled';
+    const adrFilename = `${nextNumber.toString().padStart(4, '0')}-${titleSlug}.md`;
     
     const adrContent = `# ADR ${nextNumber}: ${title}
 

--- a/tools/test/setup-fidelity.test.js
+++ b/tools/test/setup-fidelity.test.js
@@ -61,4 +61,29 @@ describe('Setup fidelity (ADR-016) — setup_architecture end-to-end', () => {
     assert.match(analysis, /Rails/, 'Rails should be detected');
     assert.match(analysis, /Express/, 'Express should be detected');
   });
+
+  it('CLAUDE.md integration points at the canonical principles path', async () => {
+    const claudeMd = await readFile(path.join(dir, 'CLAUDE.md'), 'utf8');
+    assert.match(claudeMd, /\.architecture\/principles\.md/, 'must reference canonical principles.md');
+    assert.ok(!claudeMd.includes('.architecture/decisions/principles.md'),
+      'must not reference the mislocated decisions/principles.md path (ADR-016)');
+  });
+
+  it('does not copy any node_modules into the target', () => {
+    assert.ok(!existsSync(path.join(dir, '.architecture-temp')), 'temp clone must be cleaned up');
+    assert.ok(!existsSync(path.join(dir, '.architecture', 'node_modules')),
+      'node_modules must never land in the installed .architecture');
+  });
+
+  it('createADR slugifies unsafe characters out of the filename', async () => {
+    await new ArchitectureServer().createADR({
+      title: 'Use REST/GraphQL: hybrid?',
+      context: 'ctx', decision: 'dec', consequences: 'conseq',
+      projectPath: dir,
+    });
+    const adrs = await readdir(path.join(dir, '.architecture/decisions/adrs'));
+    const created = adrs.find(f => f.includes('use-rest-graphql'));
+    assert.ok(created, `expected a slugified ADR filename, got: ${adrs.join(', ')}`);
+    assert.match(created, /^\d{4}-use-rest-graphql-hybrid\.md$/);
+  });
 });


### PR DESCRIPTION
Quality-loop review pass over `mcp/index.js` (the shipped Tier-1 server, post-ADR-015 trim). Three small correctness fixes plus one dead import, each verified against ADR-016 and covered by tests.

## Fixes

1. **Fresh installs got a CLAUDE.md pointing at a file that doesn't exist.** `setupClaudeIntegration` appended "Refer to `.architecture/decisions/principles.md`" to every target project's CLAUDE.md — the exact mislocated path ADR-016 eliminated, and which the fidelity test asserts must *not* exist. Now points at the canonical `.architecture/principles.md` (and lists it in the structure block).
2. **`create_adr` broke on titles with `/`, `:`, etc.** The filename was built from raw title text with only whitespace replaced, so a title like `Use REST/GraphQL: hybrid?` made `writeFile` target a nonexistent subdirectory and fail. The slug is now reduced to `[a-z0-9-]`.
3. **Setup could copy `tools/node_modules` into the target's temp clone.** The copy filter excluded only root and `mcp/` node_modules; after any `npm install` in `tools/` (dev machine, CI), the whole tree got copied and then deleted again. The filter now excludes any `node_modules` path segment.
4. Dropped the unused `execSync` import.

## Tests

Three additions to `tools/test/setup-fidelity.test.js`: CLAUDE.md references the canonical principles path (and not the mislocated one), no node_modules lands in the install, and `createADR` slugifies unsafe characters. `cd tools && npm test`: **102 pass, 0 fail** locally.

## Not in this PR (filed separately)

Two larger fidelity gaps surfaced by the same review are issues rather than code here: `setupTemplates`/`createADR` still hardcode divergent templates instead of deriving from the canonical `adr-template.md`/`review-template.md`, and `configure_pragmatic_mode` strips all 118 comment lines from `config.yml` via the parse/stringify round-trip.

Intended labels: `loop:quality` (applying if I have triage access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)