### PR TITLE
fix(security): harden subagent filename generation against path traversal

### DIFF
--- a/tools/lib/subagent-generator.js
+++ b/tools/lib/subagent-generator.js
@@ -7,9 +7,21 @@ const GENERATED_BANNER =
 export function generateAll(membersYaml) {
   const doc = parseYaml(membersYaml);
   const members = Array.isArray(doc?.members) ? doc.members : [];
+  const seenSlugs = new Map();
   return members
     .filter(m => m && typeof m.id === 'string' && m.id.length > 0)
-    .map(generateSubagent);
+    .map(member => {
+      const result = generateSubagent(member);
+      const priorId = seenSlugs.get(result.filename);
+      if (priorId !== undefined) {
+        throw new Error(
+          `Member ids "${priorId}" and "${member.id}" both slug to ${result.filename}; ` +
+          'ids must be distinct after slugging or one agent file would silently overwrite the other.'
+        );
+      }
+      seenSlugs.set(result.filename, member.id);
+      return result;
+    });
 }
 
 export function generateSubagent(member) {
@@ -90,7 +102,18 @@ export function parseFrontmatter(content) {
 }
 
 function idToSlug(id) {
-  return id.replace(/_/g, '-').toLowerCase();
+  // Allowlist slug: the id becomes a filename, so path separators, dots, and
+  // any other special characters must not survive (a "/" or ".." in an id
+  // would make the generated file land outside agents/). An id with nothing
+  // usable left is rejected rather than mapped to a placeholder — a
+  // traversal-only id is a mistake or an attack, not a member.
+  const slug = id.toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!slug) {
+    throw new Error(`Member id "${id}" has no characters usable in a filename; use lowercase letters, digits, and underscores.`);
+  }
+  return slug;
 }
 
 function formatDescription(title, triggerKeywords) {

--- a/tools/test/subagent-generator.test.js
+++ b/tools/test/subagent-generator.test.js
@@ -26,6 +26,26 @@ describe('Subagent Generator', () => {
       assert.strictEqual(result.filename, 'security-specialist.md');
     });
 
+    it('strips path separators from ids so filenames cannot escape agents/', () => {
+      const result = generateSubagent({ ...SAMPLE_MEMBER, id: '../../.claude/hooks/evil' });
+      assert.ok(!result.filename.includes('/'), 'filename must not contain "/"');
+      assert.ok(!result.filename.includes('\\'), 'filename must not contain "\\"');
+      assert.ok(!result.filename.includes('..'), 'filename must not contain ".."');
+      assert.strictEqual(result.filename, 'claude-hooks-evil.md');
+    });
+
+    it('slugs dots, spaces, and other special characters to hyphens', () => {
+      const result = generateSubagent({ ...SAMPLE_MEMBER, id: 'api architect v2.0' });
+      assert.strictEqual(result.filename, 'api-architect-v2-0.md');
+    });
+
+    it('rejects ids with no usable characters instead of inventing a filename', () => {
+      assert.throws(
+        () => generateSubagent({ ...SAMPLE_MEMBER, id: '../..' }),
+        /no characters usable in a filename/
+      );
+    });
+
     it('emits valid YAML frontmatter at the top of the file', () => {
       const { content } = generateSubagent(SAMPLE_MEMBER);
       assert.ok(content.startsWith('---\n'), 'must open with YAML frontmatter');
@@ -152,6 +172,14 @@ members:
       const results = generateAll(MEMBERS_YAML);
       assert.strictEqual(results[0].filename, 'security-specialist.md');
       assert.strictEqual(results[1].filename, 'performance-specialist.md');
+    });
+
+    it('throws when two ids slug to the same filename instead of silently overwriting', () => {
+      const collidingYaml = MEMBERS_YAML + '\n  - id: "security.specialist"\n    name: "Impostor"\n    perspective: "x"\n';
+      assert.throws(
+        () => generateAll(collidingYaml),
+        /both slug to security-specialist\.md/
+      );
     });
 
     it('skips entries without an id (defensive)', () => {


### PR DESCRIPTION
## What

Member ids from `.architecture/members.yml` become `agents/*.md` filenames with only underscores replaced (`idToSlug`), so an id containing `/` or `..` segments makes `node tools/cli.js generate-subagents` — or the MCP `setup_architecture` write loop — write **outside** `agents/`. Realistic vector: clone a repo shipping a hostile `members.yml`, run the documented regenerate command, and it writes attacker-controlled content to an arbitrary path (e.g. `.claude/` hooks). Same bug class as the ADR-title slugging fix in #24, one layer deeper.

## Fix

- `idToSlug` allowlist-slugs the id (`[^a-z0-9]+` → `-`, trim hyphens) and **throws** on ids with no usable characters — a traversal-only id is a mistake or an attack, not a member.
- `generateAll` **throws** when two ids slug to the same filename instead of silently last-writer-wins overwriting a sibling agent definition. Both call sites complete `generateAll` before writing, so a collision aborts with zero files written.

## Compatibility

All 8 canonical member ids are `[a-z_]` and produce byte-identical filenames before/after; `generate-subagents --check` stays green, so the CI drift gate is unaffected. The documented id contract (member-template: "Lowercase with underscores. Becomes `agents/<kebab-id>.md`") is unchanged — out-of-contract ids (dots/spaces) previously emitted frontmatter `name:` values that were already invalid as Claude Code subagent names.

Tests: 103/103 pass in `tools/` (three new traversal/collision cases).

Follow-up worth considering (not taken here): `--check` has never detected orphaned generated files in `agents/`; a banner-aware orphan warning would be cheap.

## Panel

- **The MCP pedant** — objected-then-cleared: 4 objections (silent slug-collision overwrite, `unnamed-member` fallback laundering hostile ids, inaccurate written-count claims, orphaned renames). 1–3 fixed via throw-on-collision + throw-on-empty-slug; 4 rebutted (compat constraint scoped to `.architecture/`, out-of-contract ids already broken) and the rebuttal accepted on re-review.
- **The plugin-ecosystem maintainer** — cleared: verified canonical ids byte-identical, drift gate green, and that the new slug is the first version satisfying the documented kebab dispatch contract.
- **The documentation editor** — cleared: id→filename mapping in skills docs matches; `skills/_patterns.md` filename-sanitization pattern says exactly what the new code does.
- **The cranky adopter** — cleared: fresh install produces identical `agents/*.md` before/after; 102 (now 103)/103 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)