### PR TITLE
fix(mcp): start the server when launched through the packaged bin, and cover the protocol layer

### DIFF
--- a/.github/workflows/claude-code-tests.yml
+++ b/.github/workflows/claude-code-tests.yml
@@ -41,6 +41,14 @@ jobs:
         working-directory: tools
         run: npm test
 
+      # The tools suite reaches the MCP server by importing the class, which
+      # never resolves @modelcontextprotocol/sdk. This step spawns the server
+      # over a real stdio transport so the SDK, the request handlers and the
+      # entrypoint are covered too.
+      - name: Run MCP protocol smoke test
+        working-directory: mcp
+        run: npm test
+
       - name: Validate every ADR against the template
         working-directory: tools
         run: node cli.js validate-adr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ mcp/                  # MCP Server implementation
 git clone https://github.com/codenamev/ai-software-architect
 cd ai-software-architect
 
-# Install MCP server dependencies (optional)
+# Install MCP server dependencies (required to run or test the MCP server)
 cd mcp && npm install && cd ..
 
 # Review framework structure
@@ -73,8 +73,8 @@ cat .architecture/members.yml
 # View templates
 ls .architecture/templates/
 
-# Test MCP server (if Node.js installed)
-cd mcp && npm test
+# Test MCP server
+cd mcp && npm install && npm test
 ```
 
 ## Using the Framework in Your Project
@@ -257,6 +257,7 @@ cat .architecture/templates/AGENTS.md
 **MCP Server Testing:**
 ```bash
 cd mcp
+npm install  # Required before the first run
 npm test  # Run test suite
 npm run dev  # Test in watch mode
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the AI Software Architect framework will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### MCP server exited silently when launched through its packaged `bin`
+The entrypoint guard added in 1.6.0 compared `process.argv[1]` against `__filename` as literal strings. Node resolves `import.meta.url` through symlinks but leaves `process.argv[1]` as the path it was handed, and npm installs the `mcp` bin as a symlink (`node_modules/.bin/mcp` → `../ai-software-architect/index.js`). The two never matched, so the guard did not fire: the process exited 0 with nothing on stderr and the transport was never started — a server that looks dead to its client, with no diagnostic anywhere. The comparison is now made between real paths.
+
+Scope, precisely: this affected every POSIX launch through the bin in 1.6.0, which is how `.mcp.json` starts the server (`npx -y ai-software-architect`) and how the `npm install -g` + `"command": "mcp"` configurations in `README.md` start it. Windows was unaffected — npm writes `cmd`/`ps1` shims there that hand Node the real path. Launching `node mcp/index.js` by path was also unaffected, which is why it went unnoticed. No released version shipped the bug: npm `latest` is 1.3.0, which calls `server.run()` unconditionally. This is a fix to unreleased code, not a user-facing regression.
+
+### Added
+
+#### Protocol-level smoke test for the MCP server (`mcp/test/protocol-smoke.test.js`)
+The existing suite reaches `ArchitectureServer` by importing the class, which never resolves `@modelcontextprotocol/sdk` — `mcp/index.js` loads it through dynamic `import()` inside `_initServer()`/`run()`. The SDK, the request handlers, the advertised tool schemas, the stdio transport and the entrypoint therefore had no coverage. The new tests spawn the server over a real stdio transport and assert the handshake, the exact tool set, schema well-formedness, a `tools/call` round-trip, and startup through a symlinked bin. Wired into the `validate-plugin` CI job.
+
 ## [1.6.0] - 2026-06-16
 
 ### Removed (BREAKING)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -465,7 +465,13 @@ To modify or extend the server:
 1. Edit `index.js` to add new tools or modify existing ones
 2. Update the tool schemas in the `ListToolsRequestSchema` handler
 3. Add corresponding implementation methods
-4. Test with `npm start`
+4. Install dependencies with `npm install`, then run `npm test`
+
+`npm test` spawns the server over a real stdio transport and checks the
+handshake, the advertised tool set and schemas, a `tools/call` round-trip, and
+startup through a symlinked bin. The `validate-plugin` CI job gates on it, so
+run it before opening a pull request. Use `npm start` to drive the server by
+hand once the suite passes.
 
 **Contributing**: Contributions welcome! Priority areas:
 - Pragmatic mode integration

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -1258,9 +1258,32 @@ ${new Date().toISOString().split('T')[0]}
   }
 }
 
+// True when this file is the process entrypoint rather than an imported module.
+// Both sides must be compared as real paths: __filename comes from
+// import.meta.url, which Node has already resolved through symlinks, while
+// process.argv[1] is whatever the shell was handed. Launching the package's
+// `mcp` bin hands over the node_modules/.bin symlink, so a raw string compare
+// fails and the server exits 0 without ever starting the transport - which is
+// exactly how .mcp.json invokes it (`npx -y ai-software-architect`).
+function isProcessEntrypoint(argvPath, moduleFile) {
+  if (!argvPath) return false;
+  const resolved = path.resolve(argvPath);
+  try {
+    return fs.realpathSync(resolved) === fs.realpathSync(moduleFile);
+  } catch (error) {
+    // Either path may be unreadable (deleted, permissions); fall back to the
+    // literal compare rather than throwing during module evaluation. Say so on
+    // stderr: the fallback can only ever be wrong in the direction of not
+    // starting, and an unexplained silent exit is the failure mode this
+    // function exists to remove.
+    console.error(`[MCP] entrypoint realpath check failed (${error.message}); falling back to a literal path compare`);
+    return resolved === moduleFile;
+  }
+}
+
 // Run as a server only when invoked directly; allows importing the class for
 // tests/dogfood (ADR-016 fidelity test) without starting the stdio transport.
-if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+if (isProcessEntrypoint(process.argv[1], __filename)) {
   const server = new ArchitectureServer();
   server.run().catch(console.error);
 }

--- a/mcp/test/protocol-smoke.test.js
+++ b/mcp/test/protocol-smoke.test.js
@@ -1,0 +1,166 @@
+// Protocol-level smoke test for the MCP server.
+//
+// The rest of the suite reaches ArchitectureServer's setup methods by importing
+// the class directly (tools/test/setup-fidelity.test.js), which never resolves
+// @modelcontextprotocol/sdk - index.js loads it through dynamic import() inside
+// _initServer()/run(). That leaves the SDK, the request handlers, the advertised
+// schemas and the stdio transport with no coverage at all, so a dependency bump
+// or an entrypoint change can break the server while CI stays green.
+//
+// These tests talk to a spawned server over a real stdio transport, so they fail
+// on exactly the breakage the import-based tests cannot see.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp, rm, symlink, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { ListToolsResultSchema, CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+
+const MCP_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const SERVER = path.join(MCP_DIR, 'index.js');
+
+// Every tool index.js advertises, matching mcp/README.md "Available Tools
+// (6 Tier-1 Tools)". A tool disappearing is a break for anyone whose prompts
+// reference it, so the set is asserted exactly rather than as a subset.
+const EXPECTED_TOOLS = [
+  'setup_architecture',
+  'create_adr',
+  'list_architecture_members',
+  'get_architecture_status',
+  'configure_pragmatic_mode',
+  'get_implementation_guidance',
+].sort();
+
+// Spawn the server at `entry` and return a connected client. Callers close it.
+async function connect(entry) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+  });
+  const client = new Client({ name: 'protocol-smoke', version: '1.0.0' }, { capabilities: {} });
+  await client.connect(transport);
+  return client;
+}
+
+describe('MCP protocol smoke test', () => {
+  let client;
+  let projectDir;
+
+  before(async () => {
+    projectDir = await mkdtemp(path.join(os.tmpdir(), 'asa-smoke-'));
+    client = await connect(SERVER);
+  });
+
+  after(async () => {
+    if (client) await client.close();
+    if (projectDir) await rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('completes the initialize handshake over stdio', async () => {
+    // Reaching this point already means the handshake succeeded, since connect()
+    // awaits it. The assertion pins the identity the server reports back.
+    const info = client.getServerVersion();
+    assert.strictEqual(info.name, 'ai-software-architect');
+
+    // Read rather than hardcode: tools/ already enforces single-version
+    // consistency across files (ADR-011), so hardcoding here would only add a
+    // second place to update. What this checks is that the version actually
+    // reaches the wire.
+    const pkg = JSON.parse(await readFile(path.join(MCP_DIR, 'package.json'), 'utf8'));
+    assert.strictEqual(info.version, pkg.version);
+  });
+
+  it('advertises exactly the documented tool set', async () => {
+    const { tools } = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema);
+    assert.deepStrictEqual(tools.map(t => t.name).sort(), EXPECTED_TOOLS);
+  });
+
+  it('advertises a usable inputSchema for every tool', async () => {
+    const { tools } = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema);
+    for (const tool of tools) {
+      const schema = tool.inputSchema;
+      assert.ok(schema, `${tool.name} has no inputSchema`);
+      assert.strictEqual(schema.type, 'object', `${tool.name} inputSchema is not an object schema`);
+      assert.ok(tool.description, `${tool.name} has no description`);
+
+      // A required key with no matching property is a schema a client cannot
+      // satisfy - it would prompt for a field the server never documented.
+      const properties = Object.keys(schema.properties ?? {});
+      for (const key of schema.required ?? []) {
+        assert.ok(properties.includes(key), `${tool.name} requires "${key}" but does not define it`);
+      }
+    }
+  });
+
+  it('advertises the tools capability it implements', async () => {
+    assert.ok(client.getServerCapabilities()?.tools, 'server does not advertise tools capability');
+  });
+
+  it('round-trips a tools/call successfully', async () => {
+    // list_architecture_members against an unconfigured directory is the
+    // cheapest call that exercises the CallTool handler end to end: no writes,
+    // no framework tree needed, deterministic output.
+    const result = await client.request({
+      method: 'tools/call',
+      params: { name: 'list_architecture_members', arguments: { projectPath: projectDir } },
+    }, CallToolResultSchema);
+
+    // Assert this FIRST. _setupToolHandlers catches every throw and returns a
+    // well-formed {content:[{type:'text',...}], isError:true} - so shape
+    // assertions alone pass even when the tool failed outright, which is
+    // exactly the regression this file exists to catch. Surface the server's
+    // own message when it fires.
+    assert.notStrictEqual(result.isError, true, `tools/call failed: ${result.content?.[0]?.text}`);
+
+    assert.ok(Array.isArray(result.content) && result.content.length > 0, 'no content returned');
+    assert.strictEqual(result.content[0].type, 'text');
+    assert.ok(result.content[0].text.length > 0, 'empty text content');
+  });
+
+  it('reports an unknown tool as an error rather than a success', async () => {
+    // Proves the isError assertion above has teeth in both directions: if the
+    // handler stopped signalling failure, this test goes red instead of the
+    // suite quietly accepting anything.
+    const result = await client.request({
+      method: 'tools/call',
+      params: { name: 'no_such_tool', arguments: {} },
+    }, CallToolResultSchema);
+
+    assert.strictEqual(result.isError, true, 'unknown tool was not reported as an error');
+  });
+});
+
+describe('MCP server entrypoint', () => {
+  let linkDir;
+
+  before(async () => {
+    linkDir = await mkdtemp(path.join(os.tmpdir(), 'asa-bin-'));
+  });
+
+  after(async () => {
+    if (linkDir) await rm(linkDir, { recursive: true, force: true });
+  });
+
+  it('starts when launched through a symlink, as the packaged bin is', async () => {
+    // npm installs the "mcp" bin as node_modules/.bin/mcp -> ../<pkg>/index.js,
+    // and .mcp.json launches it with `npx -y ai-software-architect`. Node
+    // resolves import.meta.url through that symlink but leaves process.argv[1]
+    // pointing at the link, so an entrypoint guard that compares the two
+    // literally never fires and the server exits 0 in silence - a dead server
+    // from the client's point of view, with nothing on stderr to explain it.
+    const link = path.join(linkDir, 'mcp');
+    await symlink(SERVER, link);
+
+    const client = await connect(link);
+    try {
+      const { tools } = await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema);
+      assert.deepStrictEqual(tools.map(t => t.name).sort(), EXPECTED_TOOLS);
+    } finally {
+      await client.close();
+    }
+  });
+});


### PR DESCRIPTION
## What this fixes

The entrypoint guard added in 1.6.0 (a1c9603) compares `process.argv[1]` to `__filename` as literal strings:

```js
if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
```

Node resolves `import.meta.url` through symlinks; `process.argv[1]` stays as the shell handed it over. npm installs the `mcp` bin as a symlink — `node_modules/.bin/mcp → ../ai-software-architect/index.js` — so the two never match, the guard never fires, and the process exits 0 with nothing on stderr. From the client's side that's a server that connects and immediately closes, with no diagnostic anywhere.

That is the path `.mcp.json` uses (`npx -y ai-software-architect`), which `.claude-plugin/plugin.json` points at — so it's the plugin's MCP path too — and the path the `npm install -g` + `"command": "mcp"` configs in `README.md` use. Launching `node mcp/index.js` by path was unaffected, which is why it went unnoticed.

Reproduced by packing and globally installing the package:

```
$ npm pack && npm install -g --prefix /tmp/gl ./ai-software-architect-1.6.0.tgz
$ ls -l /tmp/gl/bin/mcp
  mcp -> ../lib/node_modules/ai-software-architect/index.js
$ echo '' | /tmp/gl/bin/mcp
  (no output, exit 0)          <-- server never started

after this change:
$ echo '' | /tmp/gl/bin/mcp
  AI Software Architect MCP server running on stdio
```

**Scope:** POSIX launches through the bin, in 1.6.0 only. Windows is unaffected — npm writes `cmd`/`ps1` shims that hand Node the real path. And no released version shipped it: npm `latest` is 1.3.0, which calls `server.run()` unconditionally. This is a fix to unreleased code, not a user-facing regression.

## Why CI didn't catch it, and what that says about `/mcp` generally

I found this while triaging the open Dependabot PRs, trying to answer "does a green check mean anything for a `/mcp` bump?" It doesn't, and the reason generalises past this bug.

`tools/test/setup-fidelity.test.js` imports `ArchitectureServer` and drives `setupArchitecture()` end to end, so the setup logic is well covered. But nothing calls `_initServer()` or `run()` — and `mcp/index.js` loads `@modelcontextprotocol/sdk` through *dynamic* `import()` inside exactly those two methods (deliberately, per the header comment: `tools/node_modules` can't resolve it). So no test in the repo resolves the SDK at all. The SDK, the request handlers, the advertised `inputSchema`s, the stdio transport and the entrypoint had zero coverage.

That's the layer a dependency bump can break, and the layer this bug lived in.

## What's added

`mcp/test/protocol-smoke.test.js` — spawns the server over a real `StdioClientTransport` and asserts:

1. the `initialize` handshake completes, and the advertised version matches `package.json` (read, not hardcoded — `tools/lib/version-consistency.js` already pins the value; this checks it reaches the wire)
2. the `tools` capability is advertised
3. exactly the six documented tools, no more, no fewer
4. every `inputSchema` is an object schema whose `required` keys exist in `properties`
5. a `tools/call` **succeeds** — `isError` asserted before the shape assertions
6. an unknown tool is reported as an error, so assertion 5 is proven to have teeth
7. the server starts when launched through a symlink, as the packaged bin is

Wired into `validate-plugin`. Runs in ~0.2 s.

Assertion 7 is the regression test: reconstruct the old guard and it fails in ~55 ms with `MCP error -1: Connection closed` — red fast, not a hang. Assertion 5 is the one the panel forced (see below); with a deliberately throwing tool it reports `tools/call failed: Error: <server's own message>`.

Docs updated where this diff makes them wrong: `mcp/README.md` § Development said "Test with `npm start`" — the module's only testing guidance — and `AGENTS.md` documented `cd mcp && npm test` while labelling the dependency install "(optional)", which on a fresh clone now means `ERR_MODULE_NOT_FOUND`.

`mcp/package.json` is deliberately **not** touched: `"test": "node --test"` is the shell-agnostic form 1.5.3 moved to on purpose, it discovers the new test on Node 18/20/26, and it stays a harmless `tests 0 / exit 0` in the published tarball, where `.npmignore` excludes `*.test.js`.

No version bump — releases are yours (WORLD.md), so the changelog entry sits under `## [Unreleased]`.

## Classification

`code-refactor`-class under `etc/autonomy.json` → L1: I open, you merge. It changes no tool behavior and no public API; it makes a documented install path work as documented. Tell me if you'd rather have classed it otherwise.

## Follow-ups, filed rather than smuggled in

- #29 — every CI runtime pin is past EOL (Node 20, Node 18, Python 3.9), and `engines` publishes an EOL floor.
- #30 — after #20, adopt the SDK 1.x API so advertised `inputSchema` contracts are actually enforced. Today `get_architecture_status {}` returns a raw `ERR_INVALID_ARG_TYPE` string despite `required: ["projectPath"]`. Pre-existing, identical on 0.6.1.
- Not filed, worth knowing: this fix reaches no user until a publish, and #27 already tracks the registry being stale at 1.3.0. Related — the smoke test covers the entrypoint of the npx path but not its payload; the published tarball has no `../tools/lib` or `.architecture/`, so `setup_architecture` on a real `npx` install could still fail with this test green. Narrowed by this PR, not closed.

## Panel

Four adversarial reviewers were run against the finished diff before this PR was opened, each briefed to refute it. One revision round.

- **The MCP pedant** — objected-then-cleared. Blocking: the `tools/call` test asserted only content shape, which the handler's catch-all (`{content:[{type:'text'}], isError:true}`) also satisfies — a tool failing on every call would have passed green, the exact failure mode the test claims to close. Fixed by asserting `isError` first plus a negative case. On re-review it mutation-tested four ways (thrown tool error, stripped `isError`, silently-succeeding default branch) and confirmed each turns the suite red, and that the new `console.error` writes to stderr only, leaving stdout byte-clean so JSON-RPC framing is intact.
- **The plugin-ecosystem maintainer** — cleared first pass. Reconstructed an npm install layout and drove real `initialize` frames through the `.bin` symlink, a global-bin symlink and the direct path; confirmed the import path still doesn't start a transport, that the fix holds under `--preserve-symlinks-main`, and that no plugin/skill/hook surface is touched.
- **The documentation editor** — objected-then-cleared. Blocking: (1) my `node --test test/*.test.js` silently reversed the shell-agnostic decision recorded in CHANGELOG 1.5.3, undocumented — reverted; (2) `mcp/README.md` was left the divergent variant telling contributors to test via `npm start` — rewritten. It verified the corrected CHANGELOG scope claims by pulling the published 1.3.0 tarball and confirming the unconditional `run()`.
- **The cranky adopter** — objected-then-cleared. Blocking: (1) same test-script objection, reached independently, with the added evidence that bare `node --test` passes on Node 18.20.8/20.20.2/26.5.0 and that the glob would hard-fail inside the published tarball; (2) `AGENTS.md` led a fresh contributor into `ERR_MODULE_NOT_FOUND` — fixed across all four locations. On re-review it re-cloned, followed the docs as written, and confirmed the packaging fix end to end.

Two panelists independently caught the test-script mistake; that's what killed it.
