### PR TITLE
chore(deps): group Dependabot updates into a single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,22 @@ updates:
     schedule:
       interval: "weekly"
     labels: ["loop:deps"]
+    groups:
+      mcp:
+        patterns: ["*"]
   - package-ecosystem: "npm"
     directory: "/tools"
     schedule:
       interval: "weekly"
     labels: ["loop:deps"]
+    groups:
+      tools:
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels: ["loop:deps"]
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
This repo is the source of the #14–#23 PR spam: Dependabot was weekly but fully ungrouped, so every dependency got its own PR. Adds a `groups` block matching `*` to every ecosystem in `.github/dependabot.yml`, so each weekly run produces one consolidated PR per ecosystem+directory.

Note: a Dependabot group is scoped to one ecosystem + directory, so bundler and github-actions still open separate PRs — that's the floor, not a config miss. Grouping is also not retroactive; the ten already-open individual PRs stay open and need separate triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)